### PR TITLE
Pug's additions to Apoli

### DIFF
--- a/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
+++ b/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
@@ -201,18 +201,21 @@ public class ApoliDataTypes {
             .add("should_render", SerializableDataTypes.BOOLEAN, true)
             .add("bar_index", SerializableDataTypes.INT, 0)
             .add("sprite_location", SerializableDataTypes.IDENTIFIER, new Identifier("origins", "textures/gui/resource_bar.png"))
-            .add("condition", ENTITY_CONDITION, null),
+            .add("condition", ENTITY_CONDITION, null)
+            .add("inverted", SerializableDataTypes.BOOLEAN, false),
         (dataInst) -> new HudRender(
             dataInst.getBoolean("should_render"),
             dataInst.getInt("bar_index"),
             dataInst.getId("sprite_location"),
-            (ConditionFactory<LivingEntity>.Instance)dataInst.get("condition")),
+            (ConditionFactory<LivingEntity>.Instance)dataInst.get("condition"),
+            dataInst.getBoolean("inverted")),
         (data, inst) -> {
             SerializableData.Instance dataInst = data.new Instance();
             dataInst.set("should_render", inst.shouldRender());
             dataInst.set("bar_index", inst.getBarIndex());
             dataInst.set("sprite_location", inst.getSpriteLocation());
             dataInst.set("condition", inst.getCondition());
+            dataInst.set("inverted", inst.getInverted());
             return dataInst;
         });
 

--- a/src/main/java/io/github/apace100/apoli/mixin/ElytraFeatureRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ElytraFeatureRendererMixin.java
@@ -8,19 +8,34 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ElytraFeatureRenderer.class)
 public class ElytraFeatureRendererMixin {
+    @Unique
+    private LivingEntity livingEntity;
 
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isOf(Lnet/minecraft/item/Item;)Z"))
     private boolean modifyEquippedStackToElytra(ItemStack itemStack, Item item, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, LivingEntity livingEntity, float f, float g, float h, float j, float k, float l) {
+        this.livingEntity = livingEntity;
         if(PowerHolderComponent.getPowers(livingEntity, ElytraFlightPower.class).stream().anyMatch(ElytraFlightPower::shouldRenderElytra) && !livingEntity.isInvisible()) {
             return true;
         }
         return itemStack.isOf(item);
+    }
+
+    @ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/RenderLayer;getArmorCutoutNoCull(Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/RenderLayer;"))
+    private Identifier setTexture(Identifier identifier) {
+        for (ElytraFlightPower power : PowerHolderComponent.getPowers(this.livingEntity, ElytraFlightPower.class)) {
+            if (power.getTextureLocation() != null) {
+                return power.getTextureLocation();
+            }
+        }
+        return identifier;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/EntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/EntityMixin.java
@@ -55,13 +55,6 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
         }
     }
 
-    @Inject(method = "isGlowing", at = @At("HEAD"), cancellable = true)
-    private void makeEntityGlow(CallbackInfoReturnable<Boolean> cir) {
-        if (PowerHolderComponent.hasPower((Entity)(Object)this, SelfGlowPower.class)) {
-            cir.setReturnValue(true);
-        }
-    }
-
     @Shadow
     public World world;
 

--- a/src/main/java/io/github/apace100/apoli/mixin/EntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/EntityMixin.java
@@ -55,6 +55,13 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
         }
     }
 
+    @Inject(method = "isGlowing", at = @At("HEAD"), cancellable = true)
+    private void makeEntityGlow(CallbackInfoReturnable<Boolean> cir) {
+        if (PowerHolderComponent.hasPower((Entity)(Object)this, SelfGlowPower.class)) {
+            cir.setReturnValue(true);
+        }
+    }
+
     @Shadow
     public World world;
 

--- a/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
@@ -107,16 +107,6 @@ public abstract class GameRendererMixin {
     private void fixHudWithShaderEnabled(float tickDelta, long nanoTime, boolean renderLevel, CallbackInfo info) {
         RenderSystem.enableTexture();
     }
-
-    @Inject(at = @At("HEAD"), method = "toggleShadersEnabled", cancellable = true)
-    private void disableToggle(CallbackInfo ci) {
-        PowerHolderComponent.withPower(client.getCameraEntity(), ShaderPower.class, null, shaderPower -> {
-            Identifier shaderLoc = shaderPower.getShaderLocation();
-            if (!shaderPower.toggleable() && currentlyLoadedShader == shaderLoc && shadersEnabled) {
-                ci.cancel();
-            }
-        });
-    }
 /*
     @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setCameraEntity(Lnet/minecraft/entity/Entity;)V"))
     private void updateShaderPowers(CallbackInfo ci) {

--- a/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
@@ -107,6 +107,16 @@ public abstract class GameRendererMixin {
     private void fixHudWithShaderEnabled(float tickDelta, long nanoTime, boolean renderLevel, CallbackInfo info) {
         RenderSystem.enableTexture();
     }
+
+    @Inject(at = @At("HEAD"), method = "toggleShadersEnabled", cancellable = true)
+    private void disableShaderToggle(CallbackInfo ci) {
+        PowerHolderComponent.withPower(client.getCameraEntity(), ShaderPower.class, null, shaderPower -> {
+            Identifier shaderLoc = shaderPower.getShaderLocation();
+            if(!shaderPower.isToggleable() && currentlyLoadedShader == shaderLoc) {
+                ci.cancel();
+            }
+        });
+    }
 /*
     @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setCameraEntity(Lnet/minecraft/entity/Entity;)V"))
     private void updateShaderPowers(CallbackInfo ci) {

--- a/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
@@ -107,6 +107,16 @@ public abstract class GameRendererMixin {
     private void fixHudWithShaderEnabled(float tickDelta, long nanoTime, boolean renderLevel, CallbackInfo info) {
         RenderSystem.enableTexture();
     }
+
+    @Inject(at = @At("HEAD"), method = "toggleShadersEnabled", cancellable = true)
+    private void disableToggle(CallbackInfo ci) {
+        PowerHolderComponent.withPower(client.getCameraEntity(), ShaderPower.class, null, shaderPower -> {
+            Identifier shaderLoc = shaderPower.getShaderLocation();
+            if (!shaderPower.toggleable() && currentlyLoadedShader == shaderLoc && shadersEnabled) {
+                ci.cancel();
+            }
+        });
+    }
 /*
     @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setCameraEntity(Lnet/minecraft/entity/Entity;)V"))
     private void updateShaderPowers(CallbackInfo ci) {

--- a/src/main/java/io/github/apace100/apoli/mixin/MinecraftClientMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/MinecraftClientMixin.java
@@ -2,6 +2,7 @@ package io.github.apace100.apoli.mixin;
 
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.EntityGlowPower;
+import io.github.apace100.apoli.power.SelfGlowPower;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -29,8 +30,12 @@ public class MinecraftClientMixin {
                         cir.setReturnValue(true);
                     }
                 }
+                if (entity instanceof LivingEntity) {
+                    if (PowerHolderComponent.getPowers(entity, SelfGlowPower.class).stream().anyMatch(p -> p.doesApply(this.player))) {
+                        cir.setReturnValue(true);
+                    }
+                }
             }
-
         }
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/WorldRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/WorldRendererMixin.java
@@ -3,6 +3,7 @@ package io.github.apace100.apoli.mixin;
 import io.github.apace100.apoli.ApoliClient;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.EntityGlowPower;
+import io.github.apace100.apoli.power.SelfGlowPower;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -61,6 +62,15 @@ public abstract class WorldRendererMixin {
     private void setColors(Args args) {
         for (EntityGlowPower power : PowerHolderComponent.getPowers(client.getCameraEntity(), EntityGlowPower.class)) {
             if (power.doesApply(renderEntity)) {
+                if (!power.usesTeams()) {
+                    args.set(0, (int)(power.getRed() * 255.0F));
+                    args.set(1, (int)(power.getGreen() * 255.0F));
+                    args.set(2, (int)(power.getBlue() * 255.0F));
+                }
+            }
+        }
+        for (SelfGlowPower power : PowerHolderComponent.getPowers(renderEntity, SelfGlowPower.class)) {
+            if (power.isActive()) {
                 if (!power.usesTeams()) {
                     args.set(0, (int)(power.getRed() * 255.0F));
                     args.set(1, (int)(power.getGreen() * 255.0F));

--- a/src/main/java/io/github/apace100/apoli/mixin/WorldRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/WorldRendererMixin.java
@@ -1,23 +1,40 @@
 package io.github.apace100.apoli.mixin;
 
 import io.github.apace100.apoli.ApoliClient;
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import io.github.apace100.apoli.power.EntityGlowPower;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.render.Camera;
-import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.render.LightmapTextureManager;
-import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Matrix4f;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.profiler.Profiler;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+import java.util.Iterator;
 
 @Environment(EnvType.CLIENT)
 @Mixin(WorldRenderer.class)
 public abstract class WorldRendererMixin {
+
+    @Final
+    @Shadow
+    private MinecraftClient client;
+
+    @Unique
+    private Entity renderEntity;
 
     @Shadow public abstract void reload();
 
@@ -25,11 +42,31 @@ public abstract class WorldRendererMixin {
 
     @Shadow private boolean needsTerrainUpdate;
 
+    @Shadow public abstract void render(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f);
+
     @Inject(method = "render", at = @At("HEAD"))
     private void updateChunksIfRenderChanged(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, CallbackInfo ci) {
         if(ApoliClient.shouldReloadWorldRenderer) {
             reload();
             ApoliClient.shouldReloadWorldRenderer = false;
+        }
+    }
+
+    @Inject(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/entity/Entity;getTeamColorValue()I"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void getEntity(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, CallbackInfo ci, Profiler profiler, Vec3d vec3d, double d, double e, double f, Matrix4f matrix4f2, boolean bl, Frustum frustum2, boolean bl3, VertexConsumerProvider.Immediate immediate, Iterator var39, Entity entity) {
+        this.renderEntity = entity;
+    }
+
+    @ModifyArgs(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/OutlineVertexConsumerProvider;setColor(IIII)V"))
+    private void setColors(Args args) {
+        for (EntityGlowPower power : PowerHolderComponent.getPowers(client.getCameraEntity(), EntityGlowPower.class)) {
+            if (power.doesApply(renderEntity)) {
+                if (!power.usesTeams()) {
+                    args.set(0, (int)(power.getRed() * 255.0F));
+                    args.set(1, (int)(power.getGreen() * 255.0F));
+                    args.set(2, (int)(power.getBlue() * 255.0F));
+                }
+            }
         }
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/CooldownPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/CooldownPower.java
@@ -30,7 +30,7 @@ public class CooldownPower extends Power implements HudRendered {
 
     public float getProgress() {
         float time = entity.getEntityWorld().getTime() - lastUseTime;
-        return Math.min(1F, Math.max(time / (float)cooldownDuration, 0F));
+        return (hudRender.getInverted()) ? Math.min(1F, Math.max(1F - (time / (float)cooldownDuration), 0F)) : Math.min(1F, Math.max(time / (float)cooldownDuration, 0F));
     }
 
     public int getRemainingTicks() {

--- a/src/main/java/io/github/apace100/apoli/power/ElytraFlightPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ElytraFlightPower.java
@@ -2,17 +2,24 @@ package io.github.apace100.apoli.power;
 
 import net.adriantodt.fallflyinglib.FallFlyingLib;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.Identifier;
 
 public class ElytraFlightPower extends PlayerAbilityPower {
 
     private final boolean renderElytra;
+    private final Identifier textureLocation;
 
-    public ElytraFlightPower(PowerType<?> type, LivingEntity entity, boolean renderElytra) {
+    public ElytraFlightPower(PowerType<?> type, LivingEntity entity, boolean renderElytra, Identifier textureLocation) {
         super(type, entity, FallFlyingLib.ABILITY);
         this.renderElytra = renderElytra;
+        this.textureLocation = textureLocation;
     }
 
     public boolean shouldRenderElytra() {
         return renderElytra;
+    }
+
+    public Identifier getTextureLocation() {
+        return textureLocation;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/EntityGlowPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/EntityGlowPower.java
@@ -10,14 +10,38 @@ public class EntityGlowPower extends Power {
 
     private final Predicate<LivingEntity> entityCondition;
     private final Predicate<Pair<LivingEntity, LivingEntity>> bientityCondition;
+    private final boolean useTeams;
+    private final float red;
+    private final float green;
+    private final float blue;
 
-    public EntityGlowPower(PowerType<?> type, LivingEntity entity, Predicate<LivingEntity> entityCondition, Predicate<Pair<LivingEntity, LivingEntity>> bientityCondition) {
+    public EntityGlowPower(PowerType<?> type, LivingEntity entity, Predicate<LivingEntity> entityCondition, Predicate<Pair<LivingEntity, LivingEntity>> bientityCondition, boolean useTeams, float red, float green, float blue) {
         super(type, entity);
         this.entityCondition = entityCondition;
         this.bientityCondition = bientityCondition;
+        this.useTeams = useTeams;
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
     }
 
     public boolean doesApply(Entity e) {
         return e instanceof LivingEntity && (entityCondition == null || entityCondition.test((LivingEntity)e)) && (bientityCondition == null || bientityCondition.test(new Pair<>(entity, (LivingEntity)e)));
+    }
+
+    public boolean usesTeams() {
+        return useTeams;
+    }
+
+    public float getRed() {
+        return red;
+    }
+
+    public float getGreen() {
+        return green;
+    }
+
+    public float getBlue() {
+        return blue;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/HudRenderedVariableIntPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/HudRenderedVariableIntPower.java
@@ -20,7 +20,7 @@ public class HudRenderedVariableIntPower extends VariableIntPower implements Hud
 
     @Override
     public float getFill() {
-        return (this.getValue() - this.getMin()) / (float)(this.getMax() - this.getMin());
+        return (hudRender.getInverted()) ? 1.0F - (this.getValue() - this.getMin()) / (float)(this.getMax() - this.getMin()) : (this.getValue() - this.getMin()) / (float)(this.getMax() - this.getMin());
     }
 
     @Override

--- a/src/main/java/io/github/apace100/apoli/power/SelfGlowPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/SelfGlowPower.java
@@ -1,20 +1,32 @@
 package io.github.apace100.apoli.power;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.Pair;
+
+import java.util.function.Predicate;
 
 public class SelfGlowPower extends Power {
 
+    private final Predicate<LivingEntity> entityCondition;
+    private final Predicate<Pair<LivingEntity, LivingEntity>> bientityCondition;
     private final boolean useTeams;
     private final float red;
     private final float green;
     private final float blue;
 
-    public SelfGlowPower(PowerType<?> type, LivingEntity entity, boolean useTeams, float red, float green, float blue) {
+    public SelfGlowPower(PowerType<?> type, LivingEntity entity, Predicate<LivingEntity> entityCondition, Predicate<Pair<LivingEntity, LivingEntity>> bientityCondition, boolean useTeams, float red, float green, float blue) {
         super(type, entity);
+        this.entityCondition = entityCondition;
+        this.bientityCondition = bientityCondition;
         this.useTeams = useTeams;
         this.red = red;
         this.green = green;
         this.blue = blue;
+    }
+
+    public boolean doesApply(Entity e) {
+        return e instanceof LivingEntity && (entityCondition == null || entityCondition.test((LivingEntity)e)) && (bientityCondition == null || bientityCondition.test(new Pair<>((LivingEntity)e, entity)));
     }
 
     public boolean usesTeams() {

--- a/src/main/java/io/github/apace100/apoli/power/SelfGlowPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/SelfGlowPower.java
@@ -1,0 +1,35 @@
+package io.github.apace100.apoli.power;
+
+import net.minecraft.entity.LivingEntity;
+
+public class SelfGlowPower extends Power {
+
+    private final boolean useTeams;
+    private final float red;
+    private final float green;
+    private final float blue;
+
+    public SelfGlowPower(PowerType<?> type, LivingEntity entity, boolean useTeams, float red, float green, float blue) {
+        super(type, entity);
+        this.useTeams = useTeams;
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+    }
+
+    public boolean usesTeams() {
+        return useTeams;
+    }
+
+    public float getRed() {
+        return red;
+    }
+
+    public float getGreen() {
+        return green;
+    }
+
+    public float getBlue() {
+        return blue;
+    }
+}

--- a/src/main/java/io/github/apace100/apoli/power/ShaderPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ShaderPower.java
@@ -7,13 +7,19 @@ import net.minecraft.util.Identifier;
 public class ShaderPower extends Power {
 
     private final Identifier shaderLocation;
+    private final boolean toggleable;
 
-    public ShaderPower(PowerType<?> type, LivingEntity entity, Identifier shaderLocation) {
+    public ShaderPower(PowerType<?> type, LivingEntity entity, Identifier shaderLocation, boolean toggleable) {
         super(type, entity);
         this.shaderLocation = shaderLocation;
+        this.toggleable = toggleable;
     }
 
     public Identifier getShaderLocation() {
         return shaderLocation;
+    }
+
+    public boolean isToggleable() {
+        return toggleable;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/ShaderPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ShaderPower.java
@@ -7,13 +7,19 @@ import net.minecraft.util.Identifier;
 public class ShaderPower extends Power {
 
     private final Identifier shaderLocation;
+    private final boolean toggleable;
 
-    public ShaderPower(PowerType<?> type, LivingEntity entity, Identifier shaderLocation) {
+    public ShaderPower(PowerType<?> type, LivingEntity entity, Identifier shaderLocation, boolean toggleable) {
         super(type, entity);
         this.shaderLocation = shaderLocation;
+        this.toggleable = toggleable;
     }
 
     public Identifier getShaderLocation() {
         return shaderLocation;
+    }
+
+    public boolean toggleable() {
+        return toggleable;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/ShaderPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ShaderPower.java
@@ -7,19 +7,13 @@ import net.minecraft.util.Identifier;
 public class ShaderPower extends Power {
 
     private final Identifier shaderLocation;
-    private final boolean toggleable;
 
-    public ShaderPower(PowerType<?> type, LivingEntity entity, Identifier shaderLocation, boolean toggleable) {
+    public ShaderPower(PowerType<?> type, LivingEntity entity, Identifier shaderLocation) {
         super(type, entity);
         this.shaderLocation = shaderLocation;
-        this.toggleable = toggleable;
     }
 
     public Identifier getShaderLocation() {
         return shaderLocation;
-    }
-
-    public boolean toggleable() {
-        return toggleable;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -678,9 +678,10 @@ public class PowerFactories {
             .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("shader"),
             new SerializableData()
-                .add("shader", SerializableDataTypes.IDENTIFIER),
+                .add("shader", SerializableDataTypes.IDENTIFIER)
+                .add("toggleable", SerializableDataTypes.BOOLEAN, true),
             data ->
-                (type, player) -> new ShaderPower(type, player, data.getId("shader")))
+                (type, player) -> new ShaderPower(type, player, data.getId("shader"), data.getBoolean("toggleable")))
             .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("shaking"),
             new SerializableData(), data -> (BiFunction<PowerType<Power>, LivingEntity, Power>) ShakingPower::new)

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -114,9 +114,10 @@ public class PowerFactories {
             .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("elytra_flight"),
             new SerializableData()
-                .add("render_elytra", SerializableDataTypes.BOOLEAN),
+                .add("render_elytra", SerializableDataTypes.BOOLEAN)
+                .add("texture_location", SerializableDataTypes.IDENTIFIER, null),
             data ->
-                (type, player) -> new ElytraFlightPower(type, player, data.getBoolean("render_elytra")))
+                (type, player) -> new ElytraFlightPower(type, player, data.getBoolean("render_elytra"), data.getId("texture_location")))
             .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("entity_group"),
             new SerializableData()

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -779,11 +779,19 @@ public class PowerFactories {
         register(new PowerFactory<>(Apoli.identifier("entity_glow"),
             new SerializableData()
                 .add("entity_condition", ApoliDataTypes.ENTITY_CONDITION, null)
-                .add("bientity_condition", ApoliDataTypes.BIENTITY_CONDITION, null),
+                .add("bientity_condition", ApoliDataTypes.BIENTITY_CONDITION, null)
+                .add("use_teams", SerializableDataTypes.BOOLEAN, true)
+                .add("red", SerializableDataTypes.FLOAT, 1.0F)
+                .add("green", SerializableDataTypes.FLOAT, 1.0F)
+                .add("blue", SerializableDataTypes.FLOAT, 1.0F),
             data ->
                 (type, player) -> new EntityGlowPower(type, player,
                     (ConditionFactory<LivingEntity>.Instance)data.get("entity_condition"),
-                    (ConditionFactory<Pair<LivingEntity, LivingEntity>>.Instance)data.get("bientity_condition")))
+                    (ConditionFactory<Pair<LivingEntity, LivingEntity>>.Instance)data.get("bientity_condition"),
+                    data.getBoolean("use_teams"),
+                    data.getFloat("red"),
+                    data.getFloat("green"),
+                    data.getFloat("blue")))
             .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("climbing"),
             new SerializableData()

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -678,10 +678,9 @@ public class PowerFactories {
             .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("shader"),
             new SerializableData()
-                .add("shader", SerializableDataTypes.IDENTIFIER)
-                .add("toggleable", SerializableDataTypes.BOOLEAN, true),
+                .add("shader", SerializableDataTypes.IDENTIFIER),
             data ->
-                (type, player) -> new ShaderPower(type, player, data.getId("shader"), data.getBoolean("toggleable")))
+                (type, player) -> new ShaderPower(type, player, data.getId("shader")))
             .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("shaking"),
             new SerializableData(), data -> (BiFunction<PowerType<Power>, LivingEntity, Power>) ShakingPower::new)

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -796,12 +796,16 @@ public class PowerFactories {
             .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("self_glow"),
                 new SerializableData()
+                        .add("entity_condition", ApoliDataTypes.ENTITY_CONDITION, null)
+                        .add("bientity_condition", ApoliDataTypes.BIENTITY_CONDITION, null)
                         .add("use_teams", SerializableDataTypes.BOOLEAN, true)
                         .add("red", SerializableDataTypes.FLOAT, 1.0F)
                         .add("green", SerializableDataTypes.FLOAT, 1.0F)
                         .add("blue", SerializableDataTypes.FLOAT, 1.0F),
                 data ->
                         (type, player) -> new SelfGlowPower(type, player,
+                                (ConditionFactory<LivingEntity>.Instance)data.get("entity_condition"),
+                                (ConditionFactory<Pair<LivingEntity, LivingEntity>>.Instance)data.get("bientity_condition"),
                                 data.getBoolean("use_teams"),
                                 data.getFloat("red"),
                                 data.getFloat("green"),

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -793,6 +793,19 @@ public class PowerFactories {
                     data.getFloat("green"),
                     data.getFloat("blue")))
             .allowCondition());
+        register(new PowerFactory<>(Apoli.identifier("self_glow"),
+                new SerializableData()
+                        .add("use_teams", SerializableDataTypes.BOOLEAN, true)
+                        .add("red", SerializableDataTypes.FLOAT, 1.0F)
+                        .add("green", SerializableDataTypes.FLOAT, 1.0F)
+                        .add("blue", SerializableDataTypes.FLOAT, 1.0F),
+                data ->
+                        (type, player) -> new SelfGlowPower(type, player,
+                                data.getBoolean("use_teams"),
+                                data.getFloat("red"),
+                                data.getFloat("green"),
+                                data.getFloat("blue")))
+                .allowCondition());
         register(new PowerFactory<>(Apoli.identifier("climbing"),
             new SerializableData()
                 .add("allow_holding", SerializableDataTypes.BOOLEAN, true)

--- a/src/main/java/io/github/apace100/apoli/util/HudRender.java
+++ b/src/main/java/io/github/apace100/apoli/util/HudRender.java
@@ -8,18 +8,20 @@ import net.minecraft.util.Identifier;
 
 public class HudRender {
 
-    public static final HudRender DONT_RENDER = new HudRender(false, 0, Apoli.identifier("textures/gui/resource_bar.png"), null);
+    public static final HudRender DONT_RENDER = new HudRender(false, 0, Apoli.identifier("textures/gui/resource_bar.png"), null, false);
 
     private final boolean shouldRender;
     private final int barIndex;
     private final Identifier spriteLocation;
     private final ConditionFactory<LivingEntity>.Instance playerCondition;
+    private final boolean inverted;
 
-    public HudRender(boolean shouldRender, int barIndex, Identifier spriteLocation, ConditionFactory<LivingEntity>.Instance condition) {
+    public HudRender(boolean shouldRender, int barIndex, Identifier spriteLocation, ConditionFactory<LivingEntity>.Instance condition, boolean inverted) {
         this.shouldRender = shouldRender;
         this.barIndex = barIndex;
         this.spriteLocation = spriteLocation;
         this.playerCondition = condition;
+        this.inverted = inverted;
     }
 
     public Identifier getSpriteLocation() {
@@ -28,6 +30,10 @@ public class HudRender {
 
     public int getBarIndex() {
         return barIndex;
+    }
+
+    public boolean getInverted() {
+        return inverted;
     }
 
     public boolean shouldRender() {


### PR DESCRIPTION
**Feel free to pick and choose what gets into the mod**

## **Inverted Cooldown Bars**

This change allows for bars that start as filled and empty over time.
It also shouldn't break existing datapacks as inverted defaults to false.

This was already possible using resources but it is not possible with cooldowns, this makes it possible with cooldowns.

```json
"hud_render": {
    "should_render": true,
    "bar_index": 0,
    "inverted": true
}
```

## **Elytra Flight Textures**

This change allows the elytra flight power to have a texture specified. When specified the elytra's texture changes.
By default it is null. A null value makes the power display the default elytra texture.

```json
{
  "type": "apoli:elytra_flight",
  "render_elytra": true,
  "texture_location": "apoli:textures/entity/vex_elytra.png"
}
```

![Elytra Flight texture working](https://cdn.discordapp.com/attachments/813795300691017798/879686275202949120/2021-08-16_20.58.03.png)

## **RGB Color Fields for EntityGlowPower**

This change allows the entity glow power to have RGB values separated from teams. It works by swapping out the color values of the glow render but only when the entity is glowing from said power. 

```json
{
  "type": "apoli:entity_glow",
  "entity_condition": {
    "type": "apoli:and",
    "conditions": [
      {
        "type": "apoli:in_block_anywhere",
        "block_condition": {
          "type": "apoli:block",
          "block": "minecraft:cobweb"
        }
      },
      {
        "type": "apoli:entity_group",
        "group": "arthropod",
        "inverted": true
      }
    ]
  },
  "use_teams": false,
  "red": 1.0,
  "green": 0.0,
  "blue": 0.0
}
```
![Working as intended](https://cdn.discordapp.com/attachments/756024207883894814/879679325555789824/unknown.png)
![Multiple instances of the power](https://cdn.discordapp.com/attachments/756024207883894814/879679099466039336/unknown.png)

By setting `use_teams` to false (defaulted to true for compatibility reasons) you can set the `red`, `green` and `blue` fields to values. (Realistically you only want to go between 0.0 and 1.0 otherwise some unintended things happen (doesn't crash so it's fine)) After these values are set your entity glows that color.

## **Self Entity Glow**
Basically the same as `apoli:entity_glow` with the changes above but it affects the entity with the power as opposed to rendering other entities that meet the condition. It also supports the `entity_condition` and `bientity_condition` fields so you can control who sees the self entity glow.

```json
{
  "type": "apoli:self_glow",
  "use_teams": false,
  "red": 0.56862745098,
  "green": 0.89019607843,
  "blue": 0.65098039215,
  "condition": {
    "type": "apoli:in_rain"
  }
}
```
![This is fair and balanced](https://cdn.discordapp.com/attachments/756024207883894814/879725091389329508/unknown.png)
```json
{
  "type": "apoli:self_glow",
  "bientity_condition": {
    "type": "apoli:can_see"
  },
  "use_teams": false,
  "red": 1.0,
  "green": 0.0,
  "blue": 0.0
}
```
![can_see bientity condition](https://cdn.discordapp.com/attachments/756024207883894814/881499458930614283/unknown.png)
![can_see bientity condition](https://cdn.discordapp.com/attachments/756024207883894814/881499481038798908/unknown.png)

## **Toggleable field for `apoli:shader`**

Adds a field that when set to false it makes it so the specified shader is unable to be toggled via the F4 key.
```json
{
  "type": "apoli:shader",
  "shader": "minecraft:shaders/post/spider.json",
  "toggleable": false
}
```