### PR TITLE
Add `tick_rate` field for `stacking_status_effect` power type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/StackingStatusEffectPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/StackingStatusEffectPower.java
@@ -10,19 +10,21 @@ public class StackingStatusEffectPower extends StatusEffectPower {
     private final int minStack;
     private final int maxStack;
     private final int durationPerStack;
+    private final int tickRate;
 
     private int currentStack;
 
-    public StackingStatusEffectPower(PowerType<?> type, LivingEntity entity, int minStack, int maxStack, int durationPerStack) {
+    public StackingStatusEffectPower(PowerType<?> type, LivingEntity entity, int minStack, int maxStack, int durationPerStack, int tickRate) {
         super(type, entity);
         this.minStack = minStack;
         this.maxStack = maxStack;
         this.durationPerStack = durationPerStack;
+        this.tickRate = tickRate;
         this.setTicking(true);
     }
 
     public void tick() {
-        if(entity.age % 10 == 0) {
+        if(entity.age % tickRate == 0) {
             if(isActive()) {
                 currentStack += 1;
                 if(currentStack > maxStack) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -454,6 +454,7 @@ public class PowerFactories {
                 .add("min_stacks", SerializableDataTypes.INT)
                 .add("max_stacks", SerializableDataTypes.INT)
                 .add("duration_per_stack", SerializableDataTypes.INT)
+                .add("tick_rate", SerializableDataTypes.INT, 10)
                 .add("effect", SerializableDataTypes.STATUS_EFFECT_INSTANCE, null)
                 .add("effects", SerializableDataTypes.STATUS_EFFECT_INSTANCES, null),
             data ->
@@ -461,7 +462,8 @@ public class PowerFactories {
                     StackingStatusEffectPower power = new StackingStatusEffectPower(type, player,
                         data.getInt("min_stacks"),
                         data.getInt("max_stacks"),
-                        data.getInt("duration_per_stack"));
+                        data.getInt("duration_per_stack"),
+                        data.getInt("tick_rate"));
                     if(data.isPresent("effect")) {
                         power.addEffect((StatusEffectInstance)data.get("effect"));
                     }


### PR DESCRIPTION
The `tick_rate` field has a default value of `10`, which makes it compatible to existing datapacks that uses the said power type