### PR TITLE
feat: add resource operation to change_resource

### DIFF
--- a/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
+++ b/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
@@ -9,10 +9,7 @@ import io.github.apace100.apoli.power.factory.action.ActionTypes;
 import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
 import io.github.apace100.apoli.power.factory.condition.ConditionType;
 import io.github.apace100.apoli.power.factory.condition.ConditionTypes;
-import io.github.apace100.apoli.util.AttributedEntityAttributeModifier;
-import io.github.apace100.apoli.util.Comparison;
-import io.github.apace100.apoli.util.HudRender;
-import io.github.apace100.apoli.util.Space;
+import io.github.apace100.apoli.util.*;
 import io.github.apace100.calio.ClassUtil;
 import io.github.apace100.calio.SerializationHelper;
 import io.github.apace100.calio.data.SerializableData;
@@ -115,6 +112,8 @@ public class ApoliDataTypes {
         SerializableDataType.list(ITEM_ACTION);
 
     public static final SerializableDataType<Space> SPACE = SerializableDataType.enumValue(Space.class);
+
+    public static final SerializableDataType<ResourceOperation> RESOURCE_OPERATION = SerializableDataType.enumValue(ResourceOperation.class);
 
     public static final SerializableDataType<AttributedEntityAttributeModifier> ATTRIBUTED_ATTRIBUTE_MODIFIER = SerializableDataType.compound(
         AttributedEntityAttributeModifier.class,

--- a/src/main/java/io/github/apace100/apoli/util/ResourceOperation.java
+++ b/src/main/java/io/github/apace100/apoli/util/ResourceOperation.java
@@ -1,0 +1,6 @@
+package io.github.apace100.apoli.util;
+
+public enum ResourceOperation {
+    ADD,
+    SET
+}


### PR DESCRIPTION
This adjusts change_resource to allow setting the resource to a specific number while maintaining backwards compatibility with the existing power. This was chosen as opposed to a set_resource action to reduce action bloat.