### PR TITLE
Fix local/velocity X/Y spaces and add side booleans to add_velocity

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/action/BiEntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/BiEntityActions.java
@@ -94,9 +94,15 @@ public class BiEntityActions {
             .add("x", SerializableDataTypes.FLOAT, 0F)
             .add("y", SerializableDataTypes.FLOAT, 0F)
             .add("z", SerializableDataTypes.FLOAT, 0F)
+            .add("client", SerializableDataTypes.BOOLEAN, true)
+            .add("server", SerializableDataTypes.BOOLEAN, true)
             .add("set", SerializableDataTypes.BOOLEAN, false),
             (data, entities) -> {
                 Entity actor = entities.getLeft(), target = entities.getRight();
+                if (target instanceof PlayerEntity
+                    && (target.world.isClient ?
+                        !data.getBoolean("client") : !data.getBoolean("server")))
+                    return;
                 Vec3f vec = new Vec3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z"));
                 TriConsumer<Float, Float, Float> method = target::addVelocity;
                 if(data.getBoolean("set"))

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/BiEntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/BiEntityActions.java
@@ -19,7 +19,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Pair;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.Vec3f;
 import net.minecraft.util.registry.Registry;
 import org.apache.logging.log4j.util.TriConsumer;
@@ -97,14 +96,14 @@ public class BiEntityActions {
             .add("z", SerializableDataTypes.FLOAT, 0F)
             .add("set", SerializableDataTypes.BOOLEAN, false),
             (data, entities) -> {
+                Entity actor = entities.getLeft(), target = entities.getRight();
                 Vec3f vec = new Vec3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z"));
-                Vec3d delta = entities.getRight().getPos().subtract(entities.getLeft().getPos()).normalize();
-                TriConsumer<Float, Float, Float> method = entities.getRight()::addVelocity;
-                if(data.getBoolean("set")) {
-                    method = entities.getRight()::setVelocity;
-                }
-                Space.rotateVectorToBase(delta, vec);
+                TriConsumer<Float, Float, Float> method = target::addVelocity;
+                if(data.getBoolean("set"))
+                    method = target::setVelocity;
+                Space.transformVectorToBase(target.getPos().subtract(actor.getPos()), vec, actor.getYaw(), true); // vector normalized by method
                 method.accept(vec.getX(), vec.getY(), vec.getZ());
+                target.velocityModified = true;
             }));
     }
 

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
@@ -37,7 +37,6 @@ import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.Pair;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.Vec3f;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.BlockView;
@@ -202,53 +201,12 @@ public class EntityActions {
             (data, entity) -> {
                 Space space = (Space)data.get("space");
                 Vec3f vec = new Vec3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z"));
-                Vec3d vel;
-                Vec3d velH;
                 TriConsumer<Float, Float, Float> method = entity::addVelocity;
                 if(data.getBoolean("set")) {
                     method = entity::setVelocity;
                 }
-                switch(space) {
-                    case WORLD:
-                        method.accept(data.getFloat("x"), data.getFloat("y"), data.getFloat("z"));
-                        break;
-                    case LOCAL:
-                        Space.rotateVectorToBase(entity.getRotationVector(), vec);
-                        method.accept(vec.getX(), vec.getY(), vec.getZ());
-                        break;
-                    case LOCAL_HORIZONTAL:
-                        vel = entity.getRotationVector();
-                        velH = new Vec3d(vel.x, 0, vel.z);
-                        if(velH.lengthSquared() > 0.00005) {
-                            velH = velH.normalize();
-                            Space.rotateVectorToBase(velH, vec);
-                            method.accept(vec.getX(), vec.getY(), vec.getZ());
-                        }
-                        break;
-                    case VELOCITY:
-                        Space.rotateVectorToBase(entity.getVelocity(), vec);
-                        method.accept(vec.getX(), vec.getY(), vec.getZ());
-                        break;
-                    case VELOCITY_NORMALIZED:
-                        Space.rotateVectorToBase(entity.getVelocity().normalize(), vec);
-                        method.accept(vec.getX(), vec.getY(), vec.getZ());
-                        break;
-                    case VELOCITY_HORIZONTAL:
-                        vel = entity.getVelocity();
-                        velH = new Vec3d(vel.x, 0, vel.z);
-                        Space.rotateVectorToBase(velH, vec);
-                        method.accept(vec.getX(), vec.getY(), vec.getZ());
-                        break;
-                    case VELOCITY_HORIZONTAL_NORMALIZED:
-                        vel = entity.getVelocity();
-                        velH = new Vec3d(vel.x, 0, vel.z);
-                        if(velH.lengthSquared() > 0.00005) {
-                            velH = velH.normalize();
-                            Space.rotateVectorToBase(velH, vec);
-                            method.accept(vec.getX(), vec.getY(), vec.getZ());
-                        }
-                        break;
-                }
+                space.toGlobal(vec, entity);
+                method.accept(vec.getX(), vec.getY(), vec.getZ());
                 entity.velocityModified = true;
             }));
         register(new ActionFactory<>(Apoli.identifier("spawn_entity"), new SerializableData()

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
@@ -197,8 +197,14 @@ public class EntityActions {
             .add("y", SerializableDataTypes.FLOAT, 0F)
             .add("z", SerializableDataTypes.FLOAT, 0F)
             .add("space", ApoliDataTypes.SPACE, Space.WORLD)
+            .add("client", SerializableDataTypes.BOOLEAN, true)
+            .add("server", SerializableDataTypes.BOOLEAN, true)
             .add("set", SerializableDataTypes.BOOLEAN, false),
             (data, entity) -> {
+                if (entity instanceof PlayerEntity
+                    && (entity.world.isClient ?
+                    !data.getBoolean("client") : !data.getBoolean("server")))
+                    return;
                 Space space = (Space)data.get("space");
                 Vec3f vec = new Vec3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z"));
                 TriConsumer<Float, Float, Float> method = entity::addVelocity;

--- a/src/main/java/io/github/apace100/apoli/util/Space.java
+++ b/src/main/java/io/github/apace100/apoli/util/Space.java
@@ -1,17 +1,124 @@
 package io.github.apace100.apoli.util;
 
-import net.minecraft.util.math.Quaternion;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Matrix3f;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.Vec3f;
 
 public enum Space {
-    WORLD, LOCAL, LOCAL_HORIZONTAL, VELOCITY, VELOCITY_NORMALIZED, VELOCITY_HORIZONTAL, VELOCITY_HORIZONTAL_NORMALIZED;
+    WORLD,
+    LOCAL, LOCAL_HORIZONTAL, LOCAL_HORIZONTAL_NORMALIZED,
+    VELOCITY, VELOCITY_NORMALIZED, VELOCITY_HORIZONTAL, VELOCITY_HORIZONTAL_NORMALIZED;
 
-    public static void rotateVectorToBase(Vec3d newBase, Vec3f vector) {
-        Vec3d globalForward = new Vec3d(0, 0, 1);
-        Vec3d v = globalForward.crossProduct(newBase).normalize();
-        double c = Math.acos(globalForward.dotProduct(newBase));
-        Quaternion quat = new Quaternion(new Vec3f((float)v.x, (float)v.y, (float)v.z), (float)c, false);
-        vector.rotate(quat);
+    /**
+     * @author Alluysl
+     * Provides the matrix transform from the base specified by the input vector to the cardinal base.
+     * The input vector is the Z (forward) axis of the base, while the calculated X axis is orthogonal to the "left" of Z. Y is such as Z is the cross product of X and Y.
+     * If the input vector were to be vertical, the yaw is used to infer the X and Y vectors of the base.
+     * After determining the vectors of the base it builds the transformation matrix by laying each into a column (if you consider vectors as being in columns for multiplications).
+     * @param vector the input vector the base is inferred from (forward vector of local space)
+     * @param yaw the yaw of local space
+     * @return the transformation matrix from local to global space
+     * */
+    private static Matrix3f getBaseTransformMatrixFromNormalizedDirectionVector(Vec3d vector, float yaw){
+        double xX, xZ, // X vector
+            zX = 0.0D, zY = vector.getY(), zZ = 0.0D; // Z vector
+
+        if (Math.abs(zY) != 1.0F) { // Z not vertical, can infer X from it
+            // Z
+            zX = vector.getX();
+            zZ = vector.getZ();
+            // X (orthogonal to the projection of Z on the global XZ plane)
+            xX = vector.getZ();
+            xZ = -vector.getX();
+            // Normalize X
+            float xFactor = (float)(1 / Math.sqrt(xX * xX + xZ * xZ));
+            xX *= xFactor;
+            xZ *= xFactor;
+        } else {
+            // If the orientation vector points straight up or straight down, use the yaw to determine the X vector (it's "on the left")
+            // The pitch doesn't affect the X vector as it's a rotation around that same vector
+            float trigonometricYaw = -yaw * 0.0174532925F; // pi / 180 = 0.0174532925
+            xX = MathHelper.cos(trigonometricYaw);
+            xZ = -MathHelper.sin(trigonometricYaw);
+        }
+
+        Matrix3f res = new Matrix3f();
+        // X
+        res.set(0, 0, (float)xX);
+        res.set(1, 0, 0.0F); // X vector is horizontal, set its Y component (a10 (mathematically a21)) to 0
+        res.set(2, 0, (float)xZ);
+        // Y (cross product of Z and X, simplified by the fact that X has a Y component of 0)
+        res.set(0, 1, (float)(zY * xZ));
+        res.set(1, 1, (float)(zZ * xX - zX * xZ));
+        res.set(2, 1, (float)(-zY * xX));
+        // Z
+        res.set(0, 2, (float)zX);
+        res.set(1, 2, (float)zY);
+        res.set(2, 2, (float)zZ);
+        return res;
+    }
+
+    /**
+     * @author Alluysl
+     * Transforms a vector from local space to global space. The base inferred from its forward vector is orthogonal.
+     * @param baseForwardVector the base's forward (Z) vector
+     * @param vector the vector to transform
+     * @param baseYaw the yaw of the base (used in case the forward vector lacks information to infer the base)
+     * @param normalizeBase whether to normalize the base, if so all three vectors of the base will be normalized, otherwise they'll all have the length of the input forward vector
+     * */
+    public static void transformVectorToBase(Vec3d baseForwardVector, Vec3f vector, float baseYaw, boolean normalizeBase) {
+
+        double baseScaleD = baseForwardVector.length();
+        if (baseScaleD <= 0.007D){ // tweak value if too high, may be a bit too aggressive
+            vector.set(Vec3f.ZERO);
+        } else {
+            float baseScale = (float)baseScaleD;
+
+            Vec3d normalizedBase = baseForwardVector.normalize(); // the function called below assumes the base is normalized to simplify calculations (Y calculated as cross product of Z and X guaranteed to be normalized if X and Z are normalized)
+
+            Matrix3f transformMatrix = getBaseTransformMatrixFromNormalizedDirectionVector(normalizedBase, baseYaw);
+            if (!normalizeBase) // if the base wasn't supposed to get normalized, re-scale to compensate for the prior normalization
+                transformMatrix.multiply(Matrix3f.scale(baseScale, baseScale, baseScale));
+            vector.transform(transformMatrix); // matrix multiplication, vector is now in the new base :D
+        }
+    }
+
+    /**
+     * @author apace100
+     * @author Alluysl
+     * Transforms a vector from the local space of this instance to global space.
+     * The "local" space may be world space (no transformation), or relative to the entity's facing (LOCAL), its velocity (VELOCITY), et cetera
+     * @param vector the vector to transform
+     * @param entity the entity to align the local space to
+     * */
+    public void toGlobal(Vec3f vector, Entity entity){
+        Vec3d baseForwardVector;
+
+        switch (this){
+
+            case WORLD:
+                break;
+
+            case LOCAL:
+            case LOCAL_HORIZONTAL:
+            case LOCAL_HORIZONTAL_NORMALIZED:
+                baseForwardVector = entity.getRotationVector();
+                if (this != LOCAL) // horizontal
+                    baseForwardVector = new Vec3d(baseForwardVector.getX(), 0, baseForwardVector.getZ());
+                transformVectorToBase(baseForwardVector, vector, entity.getYaw(), this == LOCAL_HORIZONTAL_NORMALIZED);
+                break;
+
+            case VELOCITY:
+            case VELOCITY_NORMALIZED:
+            case VELOCITY_HORIZONTAL:
+            case VELOCITY_HORIZONTAL_NORMALIZED:
+                baseForwardVector = entity.getVelocity();
+                if (this == VELOCITY_HORIZONTAL || this == VELOCITY_HORIZONTAL_NORMALIZED)
+                    baseForwardVector = new Vec3d(baseForwardVector.getX(), 0, baseForwardVector.getZ());
+                transformVectorToBase(baseForwardVector, vector, entity.getYaw(), this == VELOCITY_NORMALIZED || this == VELOCITY_HORIZONTAL_NORMALIZED);
+                break;
+        }
     }
 }

--- a/testdata/apoli/powers/add_velocity.json
+++ b/testdata/apoli/powers/add_velocity.json
@@ -1,0 +1,100 @@
+{
+	"type": "apoli:multiple",
+
+	"towards_top_of_head_client": {
+
+		"comment": "The preferable solution in most cases",
+
+		"type": "apoli:active_self",
+		"entity_action": {
+			"type": "apoli:add_velocity",
+			"space": "local",
+			"set": true,
+			"server": false,
+			"y": 1
+		},
+		"key": {
+			"key": "key.attack"
+		}
+	},
+
+	"towards_top_of_head_server": {
+
+		"comment": "Has a little bit of a delay due to communication between the server and client, as with 'launch', and won't work with velocity spaces",
+
+		"type": "apoli:active_self",
+		"entity_action": {
+			"type": "apoli:add_velocity",
+			"space": "local",
+			"set": true,
+			"client": false,
+			"y": 1
+		},
+		"key": {
+			"key": "key.use"
+		}
+	},
+
+	"towards_top_of_head_mixed": {
+
+		"comment": "The legacy behavior of add_velocity, somewhat glitchy due to both sides potentially triggering, and server shenanigans described above and below",
+
+		"type": "apoli:active_self",
+		"entity_action": {
+			"type": "apoli:add_velocity",
+			"space": "local",
+			"set": true,
+			"y": 1
+		},
+		"key": {
+			"key": "key.pickItem"
+		}
+	},
+
+	"towards_left_of_velocity": {
+
+		"comment": "Make 'set' true for a more square-like movement when mashing the key",
+		"comment_": "Remove the line preventing the action from executing on the server...",
+		"comment__": "... and watch it destroy the velocity evaluation completely in some cases, e.g. some cases of walking, of jumping, and of creative flight",
+
+		"type": "apoli:active_self",
+		"entity_action": {
+			"type": "apoli:add_velocity",
+			"space": "velocity_normalized",
+			"server": false, "comment___" : "← this line",
+			"x": 1
+		},
+		"key": {
+			"key": "key.playerlist"
+		}
+	},
+
+	"strafe_on_hit": {
+
+		"type": "apoli:action_on_hit",
+		"bientity_action": {
+			"type": "apoli:invert",
+			"action": {
+				"type": "apoli:choice",
+				"actions": [
+					{
+						"element": {
+							"type": "apoli:add_velocity",
+							"set": true,
+							"x": -1
+						},
+						"weight": 1
+					},
+					{
+						"element": {
+							"type": "apoli:add_velocity",
+							"set": true,
+							"x": 1
+						},
+						"weight": 1
+					}
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Fix the bug where using the X and Y axes of local and velocity spaces in `add_velocity` would lead to undefined behavior
- Add `client` and `server` fields to both actions, true by default; if set false, the action will be cancelled when executed on a player on that side
- `local_horizontal` is now unnormalized, the old one is now named `local_horizontal_normalized`
- Clean up the code (switch moved from EntityActions to Space)

Tested all edge cases I could remember of, and more generic cases as well (the times are slightly underestimated):
![image](https://user-images.githubusercontent.com/48528607/137647692-b571fb39-3f43-4fa3-be60-2ab3ad018041.png)

The transformVectorToBase method is made public for access in the bi-entity action. It doesn't feel very encapsulated but - in my opinion - it's not worth creating a toGlobal static method that accepts two entities just for this purpose.

[Optimized code](https://youtu.be/wg_ySNZaQV4?t=21) by the way :P

@eggohito I have a documentation page draft, if and when this is merged, DM me