### PR TITLE
Add Update Status Effects S2C Packet

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/LivingEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LivingEntityMixin.java
@@ -5,6 +5,7 @@ import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.networking.ModPackets;
 import io.github.apace100.apoli.power.*;
 import io.github.apace100.apoli.util.StackPowerUtil;
+import io.github.apace100.apoli.util.SyncStatusEffectsUtil;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -55,6 +56,26 @@ public abstract class LivingEntityMixin extends Entity {
 
     public LivingEntityMixin(EntityType<?> type, World world) {
         super(type, world);
+    }
+
+    @Inject(method = "onStatusEffectApplied", at = @At("TAIL"))
+    private void updateStatusEffectWhenRemoved(StatusEffectInstance effectInstance, Entity source, CallbackInfo ci) {
+        SyncStatusEffectsUtil.sendStatusEffectUpdatePacket((LivingEntity)(Object)this);
+    }
+
+    @Inject(method = "onStatusEffectUpgraded", at = @At("TAIL"))
+    private void updateStatusEffectWhenRemoved(StatusEffectInstance effectInstance, boolean reapplyEffect, Entity source, CallbackInfo ci) {
+        SyncStatusEffectsUtil.sendStatusEffectUpdatePacket((LivingEntity)(Object)this);
+    }
+
+    @Inject(method = "onStatusEffectRemoved", at = @At("RETURN"))
+    private void updateStatusEffectWhenRemoved(StatusEffectInstance effectInstance, CallbackInfo ci) {
+        SyncStatusEffectsUtil.sendStatusEffectUpdatePacket((LivingEntity)(Object)this);
+    }
+
+    @Inject(method = "clearStatusEffects", at = @At("RETURN"))
+    private void updateStatusEffectWhenRemoved(CallbackInfoReturnable<Boolean> cir) {
+        SyncStatusEffectsUtil.sendStatusEffectUpdatePacket((LivingEntity)(Object)this);
     }
 
     @Inject(method = "setAttacker", at = @At("TAIL"))

--- a/src/main/java/io/github/apace100/apoli/mixin/LivingEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LivingEntityMixin.java
@@ -59,22 +59,22 @@ public abstract class LivingEntityMixin extends Entity {
     }
 
     @Inject(method = "onStatusEffectApplied", at = @At("TAIL"))
-    private void updateStatusEffectWhenRemoved(StatusEffectInstance effectInstance, Entity source, CallbackInfo ci) {
+    private void updateStatusEffectWheApplied(StatusEffectInstance effectInstance, Entity source, CallbackInfo ci) {
         SyncStatusEffectsUtil.sendStatusEffectUpdatePacket((LivingEntity)(Object)this);
     }
 
     @Inject(method = "onStatusEffectUpgraded", at = @At("TAIL"))
-    private void updateStatusEffectWhenRemoved(StatusEffectInstance effectInstance, boolean reapplyEffect, Entity source, CallbackInfo ci) {
+    private void updateStatusEffectWhenUpgraded(StatusEffectInstance effectInstance, boolean reapplyEffect, Entity source, CallbackInfo ci) {
         SyncStatusEffectsUtil.sendStatusEffectUpdatePacket((LivingEntity)(Object)this);
     }
 
-    @Inject(method = "onStatusEffectRemoved", at = @At("RETURN"))
+    @Inject(method = "onStatusEffectRemoved", at = @At("TAIL"))
     private void updateStatusEffectWhenRemoved(StatusEffectInstance effectInstance, CallbackInfo ci) {
         SyncStatusEffectsUtil.sendStatusEffectUpdatePacket((LivingEntity)(Object)this);
     }
 
     @Inject(method = "clearStatusEffects", at = @At("RETURN"))
-    private void updateStatusEffectWhenRemoved(CallbackInfoReturnable<Boolean> cir) {
+    private void updateStatusEffectWhenCleared(CallbackInfoReturnable<Boolean> cir) {
         SyncStatusEffectsUtil.sendStatusEffectUpdatePacket((LivingEntity)(Object)this);
     }
 

--- a/src/main/java/io/github/apace100/apoli/networking/ModPackets.java
+++ b/src/main/java/io/github/apace100/apoli/networking/ModPackets.java
@@ -19,4 +19,6 @@ public class ModPackets {
     public static final Identifier PREVENTED_ENTITY_USE = Apoli.identifier("prevented_entity_use");
 
     public static final Identifier SET_ATTACKER = Apoli.identifier("set_attacker");
+
+    public static final Identifier SYNC_STATUS_EFFECT = Apoli.identifier("sync_status_effect");
 }

--- a/src/main/java/io/github/apace100/apoli/util/SyncStatusEffectsUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/SyncStatusEffectsUtil.java
@@ -1,0 +1,27 @@
+package io.github.apace100.apoli.util;
+
+import io.github.apace100.apoli.networking.ModPackets;
+import io.netty.buffer.Unpooled;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.registry.Registry;
+
+public class SyncStatusEffectsUtil {
+    public static void sendStatusEffectUpdatePacket(LivingEntity living) {
+        if (living.world.isClient()) return;
+        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+        buf.writeInt(living.getId());
+        buf.writeInt(living.getActiveStatusEffects().size());
+        living.getActiveStatusEffects().forEach((effect, instance) -> {
+            buf.writeInt(Registry.STATUS_EFFECT.getRawId(effect));
+            buf.writeNbt(instance.writeNbt(new NbtCompound()));
+        });
+        for (ServerPlayerEntity player : PlayerLookup.tracking(living)) {
+            ServerPlayNetworking.send(player, ModPackets.SYNC_STATUS_EFFECT, buf);
+        }
+    }
+}


### PR DESCRIPTION
This is for powers that are handled on the client but need to be updated for other players too.

Without this packet:
- Player joins game with a rendering power with the status effect condition active on another player.
- Condition is no longer met.
- There is a desync within what the players are displayed.

With this packet
- Same as before but the desync is gone.