### PR TITLE
Add distance_from_spawn and distance_from_coordinates block/entity conditions

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/BlockConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/BlockConditions.java
@@ -59,6 +59,7 @@ public class BlockConditions {
             .add("comparison", ApoliDataTypes.COMPARISON)
             .add("compare_to", SerializableDataTypes.INT),
             (data, block) -> ((Comparison)data.get("comparison")).compare(block.getBlockPos().getY(), data.getInt("compare_to"))));
+        DistanceFromCoordinatesConditionRegistry.registerBlockCondition(BlockConditions::register);
         register(new ConditionFactory<>(Apoli.identifier("block"), new SerializableData()
             .add("block", SerializableDataTypes.BLOCK),
             (data, block) -> block.getBlockState().isOf((Block)data.get("block"))));

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/DistanceFromCoordinatesConditionRegistry.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/DistanceFromCoordinatesConditionRegistry.java
@@ -1,0 +1,202 @@
+package io.github.apace100.apoli.power.factory.condition;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.block.pattern.CachedBlockPosition;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldView;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+
+/**
+ * @author Alluysl
+ * Handles the registry of the distance_from_spawn condition in both block and entity conditions to avoid duplicating code.
+ * */
+public class DistanceFromCoordinatesConditionRegistry {
+
+    private static final ArrayList<Object> previousWarnings = new ArrayList<>();
+    private static void warnOnce(String warning, Object key){
+        if (!previousWarnings.contains(key)){
+            previousWarnings.add(key);
+            Apoli.LOGGER.warn(warning);
+        }
+    }
+    private static void warnOnce(String warning){ warnOnce(warning, warning); }
+
+    /**
+     * Warns the user of an issue getting an information needed for expected behavior, but only once (doesn't spam the console).
+     * @param object the object that couldn't be acquired
+     * @param from the object that was supposed to provide the required object
+     * @param assumption the result assumed because of the lack of information
+     * @param whatFor what the result describes
+     * @return the assumed result
+     * */
+    private static <T> T warnCouldNotGetObject(String object, String from, T assumption, String whatFor){
+        warnOnce("Could not retrieve " + object + " from " + from + " for distance_from_spawn condition, assuming " + assumption + " for " + whatFor + ".");
+        return assumption;
+    }
+
+    /**
+     * Returns an array of aliases for the condition.
+     * */
+    private static String[] getAliases(){
+        return new String[]{"distance_from_spawn", "distance_from_coordinates"};
+    }
+
+    private static SerializableData getSerializableData(String alias){
+        // Using doubles and not ints because the player position is a vector of doubles and the sqrt function (for the distance) returns a double so we might as well use that precision
+        return new SerializableData()
+            .addFunctionedDefault("reference", SerializableDataTypes.STRING, data -> alias.equals("distance_from_coordinates") ? "world_origin" : "world_spawn") // the reference point
+//          .add("check_modified_spawn", SerializableDataTypes.BOOLEAN, true) // whether to check for modified spawns
+            .add("offset_x", SerializableDataTypes.DOUBLE, 0.0) // offset to the reference point
+            .add("offset_y", SerializableDataTypes.DOUBLE, 0.0) // idem
+            .add("offset_z", SerializableDataTypes.DOUBLE, 0.0) // idem
+            .add("x", SerializableDataTypes.DOUBLE, 0.0) // adds up (instead of replacing, for simplicity) to the prior for aliasing
+            .add("y", SerializableDataTypes.DOUBLE, 0.0) // idem
+            .add("z", SerializableDataTypes.DOUBLE, 0.0) // idem
+            .add("ignore_x", SerializableDataTypes.BOOLEAN, false) // ignore the axis in the distance calculation
+            .add("ignore_y", SerializableDataTypes.BOOLEAN, false) // idem
+            .add("ignore_z", SerializableDataTypes.BOOLEAN, false) // idem
+            .add("shape", SerializableDataTypes.STRING, "euclidean") // the shape / distance type
+            .add("scale_reference_to_dimension", SerializableDataTypes.BOOLEAN, true) // whether to scale the reference's coordinates according to the dimension it's in and the player is in
+            .add("scale_distance_to_dimension", SerializableDataTypes.BOOLEAN, false) // whether to scale the calculated distance to the current dimension
+            .add("comparison", ApoliDataTypes.COMPARISON)
+            .add("compare_to", SerializableDataTypes.DOUBLE)
+            .add("result_on_wrong_dimension", SerializableDataTypes.BOOLEAN, null) // if set and the dimension is not the same as the reference's, the value to set the condition to
+            .add("round_to_digit", SerializableDataTypes.INT, null); // if set, rounds the distance to this amount of digits (e.g. 0 for unitary values, 1 for decimals, -1 for multiples of ten)
+    }
+
+    /**
+     * Infers the logically meaningful result of a distance comparison for out of bounds points (different dimension with corresponding parameter set, or infinite coordinates).
+     * @param comparison the comparison set in the data
+     * @return the result of that comparison against out-of-bounds points
+     * */
+    private static boolean compareOutOfBounds(Comparison comparison){
+        return comparison == Comparison.NOT_EQUAL || comparison == Comparison.GREATER_THAN || comparison == Comparison.GREATER_THAN_OR_EQUAL;
+    }
+
+    /**
+     * Tests the distance_from_spawn condition for either a block or an entity.
+     * No more and no less than one of either the block or entity argument must be null.
+     * @param data the condition's parsed data
+     * @param block the block to check the condition for
+     * @param entity the entity to check the condition for
+     * @return the result of the distance comparison
+     * */
+    private static boolean testCondition(SerializableData.Instance data, CachedBlockPosition block, Entity entity){
+        boolean scaleReferenceToDimension = data.getBoolean("scale_reference_to_dimension"),
+            setResultOnWrongDimension = data.isPresent("result_on_wrong_dimension"),
+            resultOnWrongDimension = setResultOnWrongDimension && data.getBoolean("result_on_wrong_dimension");
+        double x = 0, y = 0, z = 0;
+        Vec3d pos;
+        World world;
+        // Get the world and its scale from the block/entity
+        if (block != null){
+            BlockPos blockPos = block.getBlockPos();
+            pos = new Vec3d(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+            WorldView worldView = block.getWorld();
+            if (!(worldView instanceof World))
+                return warnCouldNotGetObject("world", "block", compareOutOfBounds((Comparison)data.get("comparison")), "condition");
+            else
+                world = (World)worldView;
+        } else {
+            pos = entity.getPos();
+            world = entity.getEntityWorld();
+        }
+        double currentDimensionCoordinateScale = world.getDimension().getCoordinateScale();
+
+        // Get the reference's scaled coordinates
+        switch (data.getString("reference")){
+            case "player_spawn":
+//                 if (entity instanceof ServerPlayerEntity) { // null instance of AnyClass is always false so the block case is covered
+//
+//                 }
+//                 // No break on purpose (defaulting to natural spawn)
+            case "player_natural_spawn": // spawn not set through commands or beds/anchors
+                if (entity instanceof PlayerEntity) { // && data.getBoolean("check_modified_spawn")){
+                    warnOnce("Used reference '" + data.getString("reference") + "' which is not implemented yet, defaulting to world spawn.");
+                }
+                // No break on purpose (defaulting to world spawn)
+                if (entity == null)
+                    warnOnce("Used entity-condition-only reference point in block condition, defaulting to world spawn.");
+            case "world_spawn":
+                if (setResultOnWrongDimension && world.getRegistryKey() != World.OVERWORLD)
+                    return resultOnWrongDimension;
+                BlockPos spawnPos;
+                if (world instanceof ClientWorld)
+                    spawnPos = ((ClientWorld)world).getSpawnPos();
+                else if (world instanceof ServerWorld)
+                    spawnPos = ((ServerWorld)world).getSpawnPos();
+                else
+                    return warnCouldNotGetObject("world with spawn position", block != null ? "block" : "entity", compareOutOfBounds((Comparison)data.get("comparison")), "condition");
+                x = spawnPos.getX();
+                y = spawnPos.getY();
+                z = spawnPos.getZ();
+                break;
+            case "world_origin":
+                break;
+        }
+        x += data.getDouble("x") + data.getDouble("offset_x");
+        y += data.getDouble("y") + data.getDouble("offset_y");
+        z += data.getDouble("z") + data.getDouble("offset_z");
+        if (scaleReferenceToDimension && (x != 0 || z != 0)){
+            if (currentDimensionCoordinateScale == 0) // pocket dimensions?
+                // coordinate scale 0 means it takes 0 blocks to travel in the OW to travel 1 block in the dimension,
+                // so the dimension is folded on 0 0, so unless the OW reference is at 0 0, it gets scaled to infinity
+                return compareOutOfBounds((Comparison)data.get("comparison"));
+            x /= currentDimensionCoordinateScale;
+            z /= currentDimensionCoordinateScale;
+        }
+
+        // Get the distance to these coordinates
+        double distance,
+                xDistance = data.getBoolean("ignore_x") ? 0 : Math.abs(pos.getX() - x),
+                yDistance = data.getBoolean("ignore_y") ? 0 : Math.abs(pos.getY() - y),
+                zDistance = data.getBoolean("ignore_z") ? 0 : Math.abs(pos.getZ() - z);
+        if (data.getBoolean("scale_distance_to_dimension")){
+            xDistance *= currentDimensionCoordinateScale;
+            zDistance *= currentDimensionCoordinateScale;
+        }
+        switch (data.getString("shape")) {
+            case "euclidean", "sphere" -> distance = Math.sqrt(xDistance * xDistance + yDistance * yDistance + zDistance * zDistance);
+            case "manhattan", "star" -> distance = xDistance + yDistance + zDistance;
+            case "chebyshev", "cube" -> distance = Math.max(Math.max(xDistance, yDistance), zDistance);
+            default -> { // unrecognized
+                return warnCouldNotGetObject("recognized shape name", "data", compareOutOfBounds((Comparison)data.get("comparison")), "condition (got '" + data.getString("shape") + "')");
+            }
+        }
+
+        if (data.isPresent("round_to_digit"))
+            distance = new BigDecimal(distance).setScale(data.getInt("round_to_digit"), RoundingMode.HALF_UP).doubleValue();
+
+        return ((Comparison)data.get("comparison")).compare(distance, data.getDouble("compare_to"));
+    }
+
+    // Watch Java generic type erasure destroy DRY
+
+    public static void registerBlockCondition(Consumer<ConditionFactory<CachedBlockPosition>> registryFunction){
+        for (String alias : getAliases())
+            registryFunction.accept(new ConditionFactory<>(Apoli.identifier(alias),
+                getSerializableData(alias),
+                (data, block) -> testCondition(data, block, null)));
+    }
+
+    public static void registerEntityCondition(Consumer<ConditionFactory<Entity>> registryFunction){
+        for (String alias : getAliases())
+            registryFunction.accept(new ConditionFactory<>(Apoli.identifier(alias),
+                getSerializableData(alias),
+                (data, entity) -> testCondition(data, null, entity)));
+    }
+}

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
@@ -241,6 +241,7 @@ public class EntityConditions {
                 }
                 return comparison.compare(count, compareTo);
             }));
+        DistanceFromCoordinatesConditionRegistry.registerEntityCondition(EntityConditions::register);
         register(new ConditionFactory<>(Apoli.identifier("dimension"), new SerializableData()
             .add("dimension", SerializableDataTypes.IDENTIFIER),
             (data, entity) -> entity.world.getRegistryKey() == RegistryKey.of(Registry.WORLD_KEY, data.getId("dimension"))));

--- a/src/main/java/io/github/apace100/apoli/util/Shape.java
+++ b/src/main/java/io/github/apace100/apoli/util/Shape.java
@@ -7,19 +7,32 @@ import java.util.HashSet;
 import java.util.Set;
 
 public enum Shape {
-    CUBE, STAR;
+    CUBE, CHEBYSHEV,
+    STAR, MANHATTAN,
+    SPHERE, EUCLIDEAN;
 
     public static Collection<BlockPos> getPositions(BlockPos center, Shape shape, int radius) {
         Set<BlockPos> positions = new HashSet<>();
         for(int i = -radius; i <= radius; i++) {
             for(int j = -radius; j <= radius; j++) {
                 for(int k = -radius; k <= radius; k++) {
-                    if(shape == Shape.CUBE || (Math.abs(i) + Math.abs(j) + Math.abs(k)) <= radius) {
+                    if(shape == Shape.CUBE || shape == Shape.CHEBYSHEV
+                            || (shape == Shape.SPHERE || shape == Shape.EUCLIDEAN)
+                                && Math.sqrt(i * i + j * j + k * k) <= radius
+                            || (Math.abs(i) + Math.abs(j) + Math.abs(k)) <= radius) {
                         positions.add(new BlockPos(center.add(i, j, k)));
                     }
                 }
             }
         }
         return positions;
+    }
+
+    public static double getDistance(Shape shape, double xDistance, double yDistance, double zDistance){
+        return switch (shape){
+            case SPHERE, EUCLIDEAN -> Math.sqrt(xDistance * xDistance + yDistance * yDistance + zDistance * zDistance);
+            case STAR, MANHATTAN -> xDistance + yDistance + zDistance;
+            case CUBE, CHEBYSHEV -> Math.max(Math.max(xDistance, yDistance), zDistance);
+        };
     }
 }

--- a/src/main/java/io/github/apace100/apoli/util/Shape.java
+++ b/src/main/java/io/github/apace100/apoli/util/Shape.java
@@ -19,6 +19,8 @@ public enum Shape {
                     if(shape == Shape.CUBE || shape == Shape.CHEBYSHEV
                             || (shape == Shape.SPHERE || shape == Shape.EUCLIDEAN)
                                 && i * i + j * j + k * k <= radius * radius
+                                // The radius can't be negative here (the loops aren't even entered in that case)
+                                // so there's no behavior change from testing that sqrt(i*i + j*j + k*k) <= radius
                             || (Math.abs(i) + Math.abs(j) + Math.abs(k)) <= radius) {
                         positions.add(new BlockPos(center.add(i, j, k)));
                     }

--- a/src/main/java/io/github/apace100/apoli/util/Shape.java
+++ b/src/main/java/io/github/apace100/apoli/util/Shape.java
@@ -18,7 +18,7 @@ public enum Shape {
                 for(int k = -radius; k <= radius; k++) {
                     if(shape == Shape.CUBE || shape == Shape.CHEBYSHEV
                             || (shape == Shape.SPHERE || shape == Shape.EUCLIDEAN)
-                                && Math.sqrt(i * i + j * j + k * k) <= radius
+                                && i * i + j * j + k * k <= radius * radius
                             || (Math.abs(i) + Math.abs(j) + Math.abs(k)) <= radius) {
                         positions.add(new BlockPos(center.add(i, j, k)));
                     }

--- a/testdata/apoli/powers/distance_from_spawn.json
+++ b/testdata/apoli/powers/distance_from_spawn.json
@@ -1,0 +1,45 @@
+{
+	"type": "apoli:multiple",
+
+	"tellraw": {
+
+		"comment": "Server-side test",
+		"comment_": "Note that 'within four blocks' means in the 8x8 area around it",
+		"comment__": "Also note that we ignore height here",
+
+		"type": "apoli:action_over_time",
+		"interval": 1,
+
+		"rising_action": {
+			"type": "apoli:execute_command",
+			"command": "tellraw @s \"You are now horizontally within 4 blocks of spawn\""
+		},
+
+		"falling_action": {
+			"type": "apoli:execute_command",
+			"command": "tellraw @s \"You are not within 4 blocks of spawn anymore\""
+		},
+
+		"condition": {
+			"type": "apoli:distance_from_spawn",
+			"shape": "cube",
+			"ignore_y": true,
+			"comparison": "<",
+			"compare_to": 4
+		}
+	},
+
+	"entity_glow": {
+
+		"comment": "Client-side test",
+
+		"type": "apoli:entity_glow",
+		"entity_condition": {
+			"type": "apoli:distance_from_spawn",
+			"shape": "cube",
+			"ignore_y": true,
+			"comparison": "<",
+			"compare_to": 4
+		}
+	}
+}

--- a/testdata/apoli/powers/torch_in_spherical_radius.json
+++ b/testdata/apoli/powers/torch_in_spherical_radius.json
@@ -1,0 +1,33 @@
+{
+	"type": "apoli:action_over_time",
+	"interval": 1,
+
+	"rising_action": {
+		"type": "apoli:execute_command",
+		"command": "tellraw @s \"You are now within a six blocks radius of a torch\""
+	},
+
+	"falling_action": {
+		"type": "apoli:execute_command",
+		"command": "tellraw @s \"You are now further than a radius of six blocks from any torch\""
+	},
+
+	"condition": {
+		"type": "apoli:block_in_radius",
+		"radius": 6,
+		"shape": "sphere",
+		"block_condition": {
+			"type": "apoli:or",
+			"conditions": [
+				{
+					"type": "apoli:block",
+					"block": "minecraft:torch"
+				},
+				{
+					"type": "apoli:block",
+					"block": "minecraft:wall_torch"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Add the `distance_from_spawn` and `distance_from_coordinates` entity and block conditions. They're the same but with different default values.

## Fields

The 17 fields are as follows, only 2 are mandatory:

Field  | Type | Default | Description
-------|:----:|:-------:|-------------
`reference` | String | `world_origin` (DFC)<br>`world_spawn` (DFS) |  The point to compare the distance to with.
`offset_x`/`x` | Double | 0.0 | By how much the reference should be offset on the X axis.
`offset_y`/`y` | Double | 0.0 | By how much the reference should be offset on the Y axis.
`offset_z`/`z` | Double | 0.0 | By how much the reference should be offset on the Z axis.
`ignore_x` | Boolean | `false` | Considers the distance on the X axis to be 0.
`ignore_y` | Boolean | `false` | Considers the distance on the Y axis to be 0.
`ignore_z` | Boolean | `false` | Considers the distance on the Z axis to be 0.
`shape` | Shape | `cube` |  See notes below 
`scale_reference_to_dimension` | Boolean | `true` | Whether or not to test for the coordinate the reference would have had if it "took a nether portal" to its new coordinates.
`scale_distance_to_dimension` | Boolean | `false` | Whether or not to scale the calculated distance based on the scale of the dimension the entity/block is in.<br>e.g. multiplies the distance by 8 in the nether, such as if this flag is true, it checks for the distance you'd have to travel in the overworld from a portal at the block/entity to a portal at the reference point.
`comparison` | Comparison | | How the calculated distance should be compared to the specified value.
`compare_to` | Double | | The value to compare the Y position of the block to.
`result_on_wrong_dimension` | Boolean | *optional* | If set, will override the result of the comparison if the entity/block being tested is not in the reference's dimension.
`round_to_digit` | Integer | *optional* | If set, rounds the result to the closest number with the specified amount of digits after the comma. Negative numbers work (e.g. `-2` rounds to multiples of 100).

## Rationale and explanations

- `reference` is future-proofed to add `player_spawn` and `player_natural_spawn` once the `modify_player_spawn` power type is fixed. Note that given the current two references, the scale of the reference's dimension is supposed to be 1.0 since it's the overworld in both cases. If player/power spawns are implemented, this condition will need to be reworked a little (some scaling to do in places, and I imagine two new fields), though I'm of the belief that it won't require breaking backward compatibility.
- `offset_<axis>` and `<axis>` fields add up to each other (used as a cheap method of aliasing) to move the reference point (mostly useful with `world_origin`). The difference is that semantically, for DFS we deal with an offset, and for DFC while it still technically is an offset from `0 0 0` it's more meaningful to think of the coordinates directly (example below). Thus the aliases. My idea would be to only mention the "offsetful" syntax in the documentation for `distance_from_spawn`, and only the "offsetless" syntax in that of `distance_from_coordinates`. By the way, since the center of a block is at `(floor(x) + 0.5, floor(y) + 0.5, floor(z) + 0.5)`, these fields might have to be used even if only to set all three to 0.5. I feel like it's not the job of this condition to do this offset, otherwise it would sure match with people's instinct, but not with f3.
- `ignore_<axis>` can be used for testing the distance in 1D/2D; setting this and the one for Z to `true` makes the condition equal to `height` outside of edge cases (dimensions with a coordinate scale of 0 or wrong shape or can't get World from WorldView).

## Diagram

![distance_from_coordinates_scaling](https://user-images.githubusercontent.com/48528607/140834413-4307b232-de17-492a-9f2c-8e6377e8f8d0.png)

## Example/test powers

Check out the powers added to `testdata` too.

Generic demonstrative power (different from the one in `testdata`):

```json
{
	"type": "apoli:action_over_time",
	"interval": 1,

	"rising_action": {
		"type": "apoli:execute_command",
		"command": "tellraw @s \"You are now in a radius of 8 blocks around 256 64 32\""
	},

	"falling_action": {
		"type": "apoli:execute_command",
		"command": "tellraw @s \"You are now outside the 8-block radius around 256 64 32\""
	},

	"condition": {
		"type": "apoli:distance_from_coordinates",
		"x": 256,
		"y": 64,
		"z": 32,
		"shape": "sphere",
		"comparison": "<",
		"compare_to": 8
	}
}
```

Test power (different from the one in `testdata`):
```json
{
	"type": "apoli:action_over_time",
	"interval": 1,
	"entity_action": {
		"type": "apoli:if_else",

		"if_action": {
			"type": "apoli:execute_command",
			"command": "setblock ~ 255 ~ yellow_stained_glass keep"
		},
		"else_action": {
			"type": "apoli:execute_command",
			"command": "setblock ~ 255 ~ light_blue_stained_glass keep"
		},
		"condition": {
			"type": "apoli:distance_from_spawn",
			"shape": "cube",
			"ignore_y": true,
			"comparison": "<",
			"compare_to": 4
		}
	}
}
```
Result (the low FPS is because I was testing on capped FPS):
![Overworld](https://user-images.githubusercontent.com/48528607/140827838-6709e52c-5ee9-49f6-ac2c-638a428de6e4.png)
![Nether](https://user-images.githubusercontent.com/48528607/140827909-d090342d-c111-4006-86c4-e346681ca3bb.png)

## Points of concern and more

- I wish I could split up the `testCondition` method some more, but it appears non-trivial given the edge cases that warrant early returns - else the code would be more complex or unnecessarily allocate objects.
- Some field names seem too long.
- I feel like the "warn once" feature could be useful elsewhere if separated from this class to make it more generic.