### PR TITLE
Add Bi-entity Condition and Action fields to `apoli:modify_damage_dealt` and `apoli:modify_damage_taken`

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/ModifyDamageTakenPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyDamageTakenPower.java
@@ -20,17 +20,20 @@ import java.util.function.Predicate;
 public class ModifyDamageTakenPower extends ValueModifyingPower {
 
     private final Predicate<Pair<DamageSource, Float>> condition;
+    private final Predicate<Pair<Entity, Entity>> biEntityCondition;
 
     private Consumer<Entity> attackerAction;
     private Consumer<Entity> selfAction;
+    private Consumer<Pair<Entity, Entity>> biEntityAction;
 
-    public ModifyDamageTakenPower(PowerType<?> type, LivingEntity entity, Predicate<Pair<DamageSource, Float>> condition) {
+    public ModifyDamageTakenPower(PowerType<?> type, LivingEntity entity, Predicate<Pair<DamageSource, Float>> condition, Predicate<Pair<Entity, Entity>> biEntityCondition) {
         super(type, entity);
         this.condition = condition;
+        this.biEntityCondition = biEntityCondition;
     }
 
     public boolean doesApply(DamageSource source, float damageAmount) {
-        return condition.test(new Pair(source, damageAmount));
+        return source.getAttacker() == null ? this.condition.test(new Pair(source, damageAmount)) && biEntityCondition == null : this.condition.test(new Pair(source, damageAmount)) && (biEntityCondition == null || biEntityCondition.test(new Pair(entity, source.getAttacker())));
     }
 
     public void setAttackerAction(Consumer<Entity> attackerAction) {
@@ -41,6 +44,10 @@ public class ModifyDamageTakenPower extends ValueModifyingPower {
         this.selfAction = selfAction;
     }
 
+    public void setBiEntityAction(Consumer<Pair<Entity, Entity>> biEntityAction) {
+        this.biEntityAction = biEntityAction;
+    }
+
     public void executeActions(Entity attacker) {
         if(selfAction != null) {
             selfAction.accept(entity);
@@ -48,25 +55,34 @@ public class ModifyDamageTakenPower extends ValueModifyingPower {
         if(attackerAction != null) {
             attackerAction.accept(attacker);
         }
+        if(biEntityAction != null) {
+            biEntityAction.accept(new Pair<>(entity, attacker));
+        }
     }
 
     public static PowerFactory createFactory() {
         return new PowerFactory<>(Apoli.identifier("modify_damage_taken"),
             new SerializableData()
                 .add("damage_condition", ApoliDataTypes.DAMAGE_CONDITION, null)
+                .add("bientity_condition", ApoliDataTypes.BIENTITY_CONDITION, null)
                 .add("modifier", SerializableDataTypes.ATTRIBUTE_MODIFIER, null)
                 .add("modifiers", SerializableDataTypes.ATTRIBUTE_MODIFIERS, null)
                 .add("self_action", ApoliDataTypes.ENTITY_ACTION, null)
-                .add("attacker_action", ApoliDataTypes.ENTITY_ACTION, null),
+                .add("attacker_action", ApoliDataTypes.ENTITY_ACTION, null)
+                .add("bientity_action", ApoliDataTypes.BIENTITY_ACTION, null),
             data ->
                 (type, player) -> {
                     ModifyDamageTakenPower power = new ModifyDamageTakenPower(type, player,
-                        data.isPresent("damage_condition") ? (ConditionFactory<Pair<DamageSource, Float>>.Instance)data.get("damage_condition") : dmg -> true);
+                        data.isPresent("damage_condition") ? (ConditionFactory<Pair<DamageSource, Float>>.Instance)data.get("damage_condition") : dmg -> true,
+                        (ConditionFactory<Pair<Entity, Entity>>.Instance)data.get("bientity_condition"));
                     if(data.isPresent("modifier")) {
                         power.addModifier(data.getModifier("modifier"));
                     }
                     if(data.isPresent("modifiers")) {
                         ((List<EntityAttributeModifier>)data.get("modifiers")).forEach(power::addModifier);
+                    }
+                    if(data.isPresent("bientity_action")) {
+                        power.setBiEntityAction((ActionFactory<Pair<Entity, Entity>>.Instance)data.get("bientity_action"));
                     }
                     if(data.isPresent("self_action")) {
                         power.setSelfAction((ActionFactory<Entity>.Instance)data.get("self_action"));

--- a/src/main/java/io/github/apace100/apoli/power/ModifyDamageTakenPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyDamageTakenPower.java
@@ -33,7 +33,7 @@ public class ModifyDamageTakenPower extends ValueModifyingPower {
     }
 
     public boolean doesApply(DamageSource source, float damageAmount) {
-        return source.getAttacker() == null ? this.condition.test(new Pair(source, damageAmount)) && biEntityCondition == null : this.condition.test(new Pair(source, damageAmount)) && (biEntityCondition == null || biEntityCondition.test(new Pair(entity, source.getAttacker())));
+        return source.getAttacker() == null ? this.condition.test(new Pair(source, damageAmount)) && biEntityCondition == null : this.condition.test(new Pair(source, damageAmount)) && (biEntityCondition == null || biEntityCondition.test(new Pair(source.getAttacker(), entity)));
     }
 
     public void setAttackerAction(Consumer<Entity> attackerAction) {
@@ -56,7 +56,7 @@ public class ModifyDamageTakenPower extends ValueModifyingPower {
             attackerAction.accept(attacker);
         }
         if(biEntityAction != null) {
-            biEntityAction.accept(new Pair<>(entity, attacker));
+            biEntityAction.accept(new Pair<>(attacker, entity));
         }
     }
 

--- a/testdata/apoli/powers/modify_damage_dealt.json
+++ b/testdata/apoli/powers/modify_damage_dealt.json
@@ -1,0 +1,22 @@
+{
+  "type": "apoli:modify_damage_dealt",
+  "damage_condition": {
+    "type": "apoli:amount",
+    "comparison": ">=",
+    "compare_to": 6
+  },
+  "bientity_condition": {
+    "type": "apoli:distance",
+    "comparison": "<",
+    "compare_to": 3
+  },
+  "bientity_action": {
+    "type": "apoli:add_velocity",
+    "x": -4
+  },
+  "modifier": {
+    "name": "Test damage modifier",
+    "operation": "addition",
+    "value": 4.0
+  }
+}

--- a/testdata/apoli/powers/modify_damage_taken.json
+++ b/testdata/apoli/powers/modify_damage_taken.json
@@ -1,0 +1,17 @@
+{
+  "type": "apoli:modify_damage_taken",
+  "bientity_condition": {
+    "type": "apoli:distance",
+    "comparison": "<",
+    "compare_to": 3
+  },
+  "bientity_action": {
+    "type": "apoli:add_velocity",
+    "z": 1
+  },
+  "modifier": {
+    "name": "Test damage modifier",
+    "operation": "addition",
+    "value": 4.0
+  }
+}

--- a/testdata/apoli/powers/modify_damage_taken_no_bientity.json
+++ b/testdata/apoli/powers/modify_damage_taken_no_bientity.json
@@ -1,0 +1,16 @@
+{
+  "type": "apoli:modify_damage_taken",
+  "damage_condition": {
+    "type": "apoli:name",
+    "name": "fall"
+  },
+  "self_action": {
+    "type": "apoli:add_velocity",
+    "z": -4
+  },
+  "modifier": {
+    "name": "Test damage modifier",
+    "operation": "multiply_base",
+    "value": 2.0
+  }
+}


### PR DESCRIPTION
## Modify Damage Dealt.
`modify_damage_dealt` is fairly straightforward since a target always exists in this case.

Basically it handles the check as you'd expect it to. Being that if the bi-entity condition is null or the power holder and target fit the condition, it returns true.

## Modify Damage Taken
We've discussed the issue with adding a bientity condition to `modify_damage_taken` before, however I've come up with a solution for this.

If you have a `bientity_condition` field specified, the damage source requires an attacker to actually work, with the non attacker damage condition only returning true if the bientity_condition is null.

If there is an attacker it'll check for if the bientity condition is null or if the attacker and power holder respectively the fits the bientity condition.