### PR TITLE
Make the `block_state` block condition type return true if the block state exists in the block

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/BlockConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/BlockConditions.java
@@ -137,7 +137,7 @@ public class BlockConditions {
                 for(Property<?> p : properties) {
                     if(p.getName().equals(desiredPropertyName)) {
                         property = p;
-                        break;
+                        return true;
                     }
                 }
                 if(property != null) {


### PR DESCRIPTION
This PR replaces the `break;` statement in line 140 to `return true;` so that it'll return true if the block state exists in the block