### PR TITLE
Fix `inventory` power type not dropping its items upon losing the power

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
@@ -176,19 +176,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Nameable
     @Inject(method = "dropInventory", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;dropAll()V"))
     private void dropAdditionalInventory(CallbackInfo ci) {
         PowerHolderComponent.getPowers(this, InventoryPower.class).forEach(inventory -> {
-            if(inventory.shouldDropOnDeath()) {
-                for(int i = 0; i < inventory.size(); ++i) {
-                    ItemStack itemStack = inventory.getStack(i);
-                    if(inventory.shouldDropOnDeath(itemStack)) {
-                        if (!itemStack.isEmpty() && EnchantmentHelper.hasVanishingCurse(itemStack)) {
-                            inventory.removeStack(i);
-                        } else {
-                            ((PlayerEntity)(Object)this).dropItem(itemStack, true, false);
-                            inventory.setStack(i, ItemStack.EMPTY);
-                        }
-                    }
-                }
-            }
+            inventory.dropContents();
         });
         PowerHolderComponent.getPowers(this, KeepInventoryPower.class).forEach(keepInventoryPower -> {
             keepInventoryPower.preventItemsFromDropping(inventory);

--- a/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
@@ -175,7 +175,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Nameable
     @Inject(method = "dropInventory", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;dropAll()V"))
     private void dropAdditionalInventory(CallbackInfo ci) {
         PowerHolderComponent.getPowers(this, InventoryPower.class).forEach(inventoryPower -> {
-            inventoryPower.dropContents();
+            inventoryPower.dropContents("onDeath");
         });
         PowerHolderComponent.getPowers(this, KeepInventoryPower.class).forEach(keepInventoryPower -> {
             keepInventoryPower.preventItemsFromDropping(inventory);

--- a/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
@@ -6,7 +6,6 @@ import io.github.apace100.apoli.networking.ModPackets;
 import io.github.apace100.apoli.power.*;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.*;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.mob.MobEntity;
@@ -175,8 +174,8 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Nameable
 
     @Inject(method = "dropInventory", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;dropAll()V"))
     private void dropAdditionalInventory(CallbackInfo ci) {
-        PowerHolderComponent.getPowers(this, InventoryPower.class).forEach(inventory -> {
-            inventory.dropContents();
+        PowerHolderComponent.getPowers(this, InventoryPower.class).forEach(inventoryPower -> {
+            inventoryPower.dropContents();
         });
         PowerHolderComponent.getPowers(this, KeepInventoryPower.class).forEach(keepInventoryPower -> {
             keepInventoryPower.preventItemsFromDropping(inventory);

--- a/src/main/java/io/github/apace100/apoli/power/InventoryPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/InventoryPower.java
@@ -35,8 +35,6 @@ public class InventoryPower extends Power implements Active, Inventory {
     private boolean lostPower;
     private boolean inventoryPlayerFull;
 
-    private int inventoryPlayerOccupiedSlots;
-
     public InventoryPower(PowerType<?> type, LivingEntity entity, String containerName, int size, boolean shouldDropOnDeath, Predicate<ItemStack> dropOnDeathFilter) {
         super(type, entity);
         this.size = size;
@@ -134,7 +132,7 @@ public class InventoryPower extends Power implements Active, Inventory {
     //  Count how many player inventory slots are occupied by an item stack
     //  (called to check if the player's inventory is full)
     public void checkInventoryPlayerFull() {
-        inventoryPlayerOccupiedSlots = 0;
+        int inventoryPlayerOccupiedSlots = 0;
         PlayerEntity player = (PlayerEntity) entity;
         PlayerInventory inventoryPlayer = player.getInventory();
         int inventoryPlayerSlots = player.getInventory().main.size();

--- a/src/main/java/io/github/apace100/apoli/power/InventoryPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/InventoryPower.java
@@ -139,7 +139,6 @@ public class InventoryPower extends Power implements Active, Inventory {
             ItemStack currentItemStack = inventory.get(i);
             if (!lostPower && shouldDropOnDeath) {
                 if (shouldDropOnDeath(currentItemStack)) {
-                    Apoli.LOGGER.info(currentItemStack.getName() + " matches the filter " + dropOnDeathFilter.toString());
                     if (!currentItemStack.isEmpty() && EnchantmentHelper.hasVanishingCurse(currentItemStack)) {
                         inventory.set(i, ItemStack.EMPTY);
                     }

--- a/src/main/java/io/github/apace100/apoli/power/InventoryPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/InventoryPower.java
@@ -134,23 +134,28 @@ public class InventoryPower extends Power implements Active, Inventory {
     //  Drop the cached item stacks of the power
     //  (used for losing the power and death (if shouldDropOnDeath is true))
     public void dropContents() {
-        for (int i = 0; i < size; ++i) {
-            PlayerEntity player = (PlayerEntity)entity;
-            ItemStack currentItemStack = inventory.get(i);
-            if (!lostPower && shouldDropOnDeath) {
-                if (shouldDropOnDeath(currentItemStack)) {
-                    if (!currentItemStack.isEmpty() && EnchantmentHelper.hasVanishingCurse(currentItemStack)) {
-                        inventory.set(i, ItemStack.EMPTY);
-                    }
-                    else {
+        PlayerEntity player = (PlayerEntity) entity;
+        if (!lostPower && shouldDropOnDeath) {
+            for (int i = 0; i < size; ++i) {
+                ItemStack currentItemStack = inventory.get(i);
+                if (!currentItemStack.isEmpty() && shouldDropOnDeath(currentItemStack)) {
+                    if (!EnchantmentHelper.hasVanishingCurse(currentItemStack)) {
                         player.dropItem(currentItemStack, true, false);
-                        inventory.set(i, ItemStack.EMPTY);
                     }
+                    inventory.set(i, ItemStack.EMPTY);
                 }
             }
-            else {
-                player.dropItem(currentItemStack, true, false);
-                inventory.set(i, ItemStack.EMPTY);
+        }
+        else if (lostPower) {
+            for (int i = 0; i < size; ++i) {
+                ItemStack currentItemStack = inventory.get(i);
+                if (!currentItemStack.isEmpty()) {
+                    boolean insertedCurItemStack = player.getInventory().insertStack(currentItemStack);
+                    if (!insertedCurItemStack) {
+                        player.dropItem(currentItemStack, false, false);
+                    }
+                    inventory.set(i, ItemStack.EMPTY);
+                }
             }
         }
     }

--- a/src/main/java/io/github/apace100/apoli/power/InventoryPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/InventoryPower.java
@@ -3,7 +3,6 @@ package io.github.apace100.apoli.power;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.factory.PowerFactory;
-import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -25,24 +24,19 @@ import java.util.function.Predicate;
 
 public class InventoryPower extends Power implements Active, Inventory {
 
-    private final int size;
-    private final DefaultedList<ItemStack> inventoryPower;
+    private final int containerSize;
+    private final DefaultedList<ItemStack> containerContents;
+    private final ScreenHandlerFactory containerFactory;
     private final TranslatableText containerName;
-    private final ScreenHandlerFactory factory;
     private final boolean shouldDropOnDeath;
     private final Predicate<ItemStack> dropOnDeathFilter;
 
-    private boolean lostPower;
-    private boolean inventoryPlayerFull;
-
-    public InventoryPower(PowerType<?> type, LivingEntity entity, String containerName, int size, boolean shouldDropOnDeath, Predicate<ItemStack> dropOnDeathFilter) {
+    public InventoryPower(PowerType<?> type, LivingEntity entity, String containerName, int containerRows, int containerColumns, boolean shouldDropOnDeath, Predicate<ItemStack> dropOnDeathFilter) {
         super(type, entity);
-        this.size = size;
-        this.inventoryPower = DefaultedList.ofSize(size, ItemStack.EMPTY);
+        this.containerFactory = (i, playerInventory, playerEntity) -> new Generic3x3ContainerScreenHandler(i, playerInventory, this);
+        this.containerSize = containerRows * containerColumns;
         this.containerName = new TranslatableText(containerName);
-        this.factory = (i, playerInventory, playerEntity) -> {
-            return new Generic3x3ContainerScreenHandler(i, playerInventory, this);
-        };
+        this.containerContents = DefaultedList.ofSize(containerSize, ItemStack.EMPTY);
         this.shouldDropOnDeath = shouldDropOnDeath;
         this.dropOnDeathFilter = dropOnDeathFilter;
     }
@@ -52,60 +46,58 @@ public class InventoryPower extends Power implements Active, Inventory {
         if(!isActive()) {
             return;
         }
-        if(!entity.world.isClient && entity instanceof PlayerEntity) {
-            PlayerEntity player = (PlayerEntity)entity;
-            player.openHandledScreen(new SimpleNamedScreenHandlerFactory(factory, containerName));
+        if(!entity.world.isClient && entity instanceof PlayerEntity player) {
+            player.openHandledScreen(new SimpleNamedScreenHandlerFactory(containerFactory, containerName));
         }
     }
 
     @Override
     public void onLost() {
-        lostPower = true;
-        dropContents();
+        dropContents("onLost");
     }
 
     @Override
     public NbtCompound toTag() {
         NbtCompound tag = new NbtCompound();
-        Inventories.writeNbt(tag, inventoryPower);
+        Inventories.writeNbt(tag, containerContents);
         return tag;
     }
 
     @Override
     public void fromTag(NbtElement tag) {
-        Inventories.readNbt((NbtCompound)tag, inventoryPower);
+        Inventories.readNbt((NbtCompound)tag, containerContents);
     }
 
     @Override
     public int size() {
-        return size;
+        return containerSize;
     }
 
     @Override
     public boolean isEmpty() {
-        return inventoryPower.isEmpty();
+        return containerContents.isEmpty();
     }
 
     @Override
     public ItemStack getStack(int slot) {
-        return inventoryPower.get(slot);
+        return containerContents.get(slot);
     }
 
     @Override
     public ItemStack removeStack(int slot, int amount) {
-        return inventoryPower.get(slot).split(amount);
+        return containerContents.get(slot).split(amount);
     }
 
     @Override
     public ItemStack removeStack(int slot) {
-        ItemStack stack = inventoryPower.get(slot);
+        ItemStack stack = containerContents.get(slot);
         setStack(slot, ItemStack.EMPTY);
         return stack;
     }
 
     @Override
     public void setStack(int slot, ItemStack stack) {
-        inventoryPower.set(slot, stack);
+        containerContents.set(slot, stack);
     }
 
     @Override
@@ -120,8 +112,43 @@ public class InventoryPower extends Power implements Active, Inventory {
 
     @Override
     public void clear() {
-        for(int i = 0; i < size; i++) {
+        for(int i = 0; i < containerSize; i++) {
             setStack(i, ItemStack.EMPTY);
+        }
+    }
+
+    /**
+     * Appends the provided item stack to the player's inventory
+     */
+    public void appendStack(ItemStack stack) {
+        PlayerEntity player = (PlayerEntity) entity;
+        PlayerInventory playerInventory = player.getInventory();
+        playerInventory.insertStack(stack);
+    }
+
+    /**
+     * Appends the provided item stack to the player's inventory unless the player's inventory is full. If the player's inventory is full, it'll
+     * drop the item on the ground instead (as if the player has thrown the item).
+     */
+    public void giveStack(ItemStack stack, boolean withVanishingCurse) {
+        if (isInventoryPlayerFull()) {
+            dropStack(stack, false, true, withVanishingCurse);
+        }
+        else {
+            appendStack(stack);
+        }
+    }
+
+    /**
+     * Drops the provided item stack on the ground.
+     */
+    public void dropStack(ItemStack stack, boolean throwRandomly, boolean retainOwnership, boolean withVanishingCurse) {
+        PlayerEntity player = (PlayerEntity) entity;
+        if (withVanishingCurse) {
+            player.dropItem(stack, throwRandomly, retainOwnership);
+        }
+        else if (!EnchantmentHelper.hasVanishingCurse(stack)) {
+            player.dropItem(stack, throwRandomly, retainOwnership);
         }
     }
 
@@ -129,9 +156,10 @@ public class InventoryPower extends Power implements Active, Inventory {
         return shouldDropOnDeath && dropOnDeathFilter.test(stack);
     }
 
-    //  Count how many player inventory slots are occupied by an item stack
-    //  (called to check if the player's inventory is full)
-    public void checkInventoryPlayerFull() {
+    /**
+     * Determines if the player's inventory is full.
+     */
+    public boolean isInventoryPlayerFull() {
         int inventoryPlayerOccupiedSlots = 0;
         PlayerEntity player = (PlayerEntity) entity;
         PlayerInventory inventoryPlayer = player.getInventory();
@@ -142,38 +170,40 @@ public class InventoryPower extends Power implements Active, Inventory {
                 inventoryPlayerOccupiedSlots++;
             }
         }
-        inventoryPlayerFull = inventoryPlayerOccupiedSlots >= inventoryPlayerSlots;
+        return inventoryPlayerOccupiedSlots >= inventoryPlayerSlots;
     }
 
-    //  Drop the cached item stacks of the power
-    //  (called when the player dies or loses the power)
-    public void dropContents() {
-        PlayerEntity player = (PlayerEntity) entity;
-        if (!lostPower && shouldDropOnDeath) {
-            for (int i = 0; i < size; ++i) {
-                ItemStack currentItemStack = inventoryPower.get(i);
-                if (!currentItemStack.isEmpty() && shouldDropOnDeath(currentItemStack)) {
-                    if (!EnchantmentHelper.hasVanishingCurse(currentItemStack)) {
-                        player.dropItem(currentItemStack, true, false);
+    /**
+     * Drop the cached contents of the power upon call
+     */
+    public void dropContents(String event) {
+        switch (event) {
+            case "onDeath":
+                if (shouldDropOnDeath) {
+                    for (int i = 0; i < containerSize; ++i) {
+                        ItemStack currentItemStack = getStack(i);
+                        if (shouldDropOnDeath(currentItemStack)) {
+                            dropStack(currentItemStack, true, false, false);
+                            removeStack(i);
+                        }
                     }
-                    inventoryPower.set(i, ItemStack.EMPTY);
                 }
-            }
-        }
-        else if (lostPower) {
-            for (int i = 0; i < size; ++i) {
-                checkInventoryPlayerFull();
-                ItemStack currentItemStack = inventoryPower.get(i);
-                if (!currentItemStack.isEmpty()) {
-                    if (inventoryPlayerFull) {
-                        player.dropItem(currentItemStack, false, false);
-                    }
-                    else {
-                        player.getInventory().insertStack(currentItemStack);
-                    }
-                    inventoryPower.set(i, ItemStack.EMPTY);
+                break;
+            case "onLost":
+                for (int i = 0; i < containerSize; ++i) {
+                    ItemStack currentItemStack = getStack(i);
+                    giveStack(currentItemStack, true);
+                    removeStack(i);
                 }
-            }
+                break;
+            //  If `event` is neither "onLost" or "onDeath", drop the cached item stacks in a random fashion
+            default:
+                for (int i = 0; i < containerSize; ++i) {
+                    ItemStack currentItemStack = getStack(i);
+                    dropStack(currentItemStack, true, false, true);
+                    removeStack(i);
+                }
+                break;
         }
     }
 
@@ -198,11 +228,15 @@ public class InventoryPower extends Power implements Active, Inventory {
                 .add("key", ApoliDataTypes.BACKWARDS_COMPATIBLE_KEY, new Active.Key()),
             data ->
                 (type, player) -> {
-                    InventoryPower power = new InventoryPower(type, player, data.getString("title"), 9,
+                    InventoryPower power = new InventoryPower(
+                        type,
+                        player,
+                        data.getString("title"),
+                        3,
+                        3,
                         data.getBoolean("drop_on_death"),
-                        data.isPresent("drop_on_death_filter") ? (ConditionFactory<ItemStack>.Instance) data.get("drop_on_death_filter") :
-                            itemStack -> true);
-                    power.setKey((Active.Key)data.get("key"));
+                        data.isPresent("drop_on_death_filter") ? data.get("drop_on_death_filter") : itemStack -> true);
+                    power.setKey(data.get("key"));
                     return power;
                 })
             .allowCondition();


### PR DESCRIPTION
This PR makes it so that the stored items in a power that uses the `inventory` power type will be dropped on the ground (in a similar fashion to how items are dropped when the player dies) if the power is lost instead of being lost forever.