### PR TITLE
Add `remove_power` entity action

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
@@ -8,6 +8,7 @@ import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.*;
 import io.github.apace100.apoli.power.factory.action.entity.RaycastAction;
+import io.github.apace100.apoli.power.factory.action.entity.RemovePowerAction;
 import io.github.apace100.apoli.power.factory.action.entity.SpawnParticlesAction;
 import io.github.apace100.apoli.power.factory.action.entity.SwingHandAction;
 import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
@@ -582,6 +583,7 @@ public class EntityActions {
         register(SwingHandAction.getFactory());
         register(RaycastAction.getFactory());
         register(SpawnParticlesAction.getFactory());
+        register(RemovePowerAction.getFactory());
     }
 
     private static void register(ActionFactory<Entity> actionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/RemovePowerAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/RemovePowerAction.java
@@ -1,0 +1,38 @@
+package io.github.apace100.apoli.power.factory.action.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.PowerType;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public class RemovePowerAction {
+
+    public static void action(SerializableData.Instance data, Entity entity) {
+        PowerHolderComponent.KEY.maybeGet(entity).ifPresent(
+            component -> {
+                PowerType power = data.get("power");
+                List<Identifier> sources = component.getSources(power);
+                for (Identifier source : sources) {
+                    component.removePower(power, source);
+                }
+                if (sources.size() > 0) {
+                    component.sync();
+                }
+            }
+        );
+    }
+
+    public static ActionFactory<Entity> getFactory() {
+        return new ActionFactory<>(Apoli.identifier("remove_power"),
+            new SerializableData()
+                .add("power", ApoliDataTypes.POWER_TYPE),
+            RemovePowerAction::action
+        );
+    }
+}


### PR DESCRIPTION
Essentially, just the `remove` parameter from the `/power` command but as an entity action type, so one can dynamically reference super/sub-powers