### PR TITLE
Add `change_insomnia_ticks` entity action type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
@@ -7,6 +7,7 @@ import io.github.apace100.apoli.action.entity.EnderChestAction;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.*;
+import io.github.apace100.apoli.power.factory.action.entity.ChangeInsomniaTicksAction;
 import io.github.apace100.apoli.power.factory.action.entity.RaycastAction;
 import io.github.apace100.apoli.power.factory.action.entity.SpawnParticlesAction;
 import io.github.apace100.apoli.power.factory.action.entity.SwingHandAction;
@@ -582,6 +583,7 @@ public class EntityActions {
         register(SwingHandAction.getFactory());
         register(RaycastAction.getFactory());
         register(SpawnParticlesAction.getFactory());
+        register(ChangeInsomniaTicksAction.getFactory());
     }
 
     private static void register(ActionFactory<Entity> actionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ChangeInsomniaTicksAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ChangeInsomniaTicksAction.java
@@ -1,0 +1,46 @@
+package io.github.apace100.apoli.power.factory.action.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.apoli.util.ResourceOperation;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.stat.ServerStatHandler;
+import net.minecraft.stat.Stat;
+import net.minecraft.stat.Stats;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+public class ChangeInsomniaTicksAction {
+
+    public static void action(SerializableData.Instance data, Entity entity) {
+        if (!(entity instanceof ServerPlayerEntity serverPlayerEntity)) return;
+
+        Stat<Identifier> stat = Stats.CUSTOM.getOrCreateStat(Stats.TIME_SINCE_REST);
+        ServerStatHandler serverStatHandler = serverPlayerEntity.getStatHandler();
+        ResourceOperation operation = data.get("operation");
+
+        int newValue = 0;
+        int change = data.getInt("change");
+        int originalValue = serverStatHandler.getStat(stat);
+
+        serverPlayerEntity.resetStat(stat);
+
+        if (operation == ResourceOperation.ADD) newValue = MathHelper.clamp(change, 0, Integer.MAX_VALUE);
+        else if (operation == ResourceOperation.SET) newValue = MathHelper.clamp(originalValue + change, 0, Integer.MAX_VALUE);
+
+        serverPlayerEntity.increaseStat(stat, newValue);
+    }
+
+    public static ActionFactory<Entity> getFactory() {
+        return new ActionFactory<>(Apoli.identifier("change_insomnia_ticks"),
+            new SerializableData()
+                .add("change", SerializableDataTypes.INT)
+                .add("operation", ApoliDataTypes.RESOURCE_OPERATION, ResourceOperation.ADD),
+            ChangeInsomniaTicksAction::action
+        );
+    }
+}


### PR DESCRIPTION
This PR adds an entity action type that can change the player's `custom:time_since_rest` statistic, which is used for spawning phantoms on a player. The new value is clamped to 0 to 2,147,483,647