### PR TITLE
Make the `prevent_item_use` power type work on block items

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/BlockItemMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/BlockItemMixin.java
@@ -2,30 +2,44 @@ package io.github.apace100.apoli.mixin;
 
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.PreventItemUsePower;
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
-import net.minecraft.world.World;
+import net.minecraft.item.ItemUsageContext;
+import net.minecraft.util.ActionResult;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(BlockItem.class)
 public class BlockItemMixin {
 
-    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/item/BlockItem;use(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/TypedActionResult;"), method = "useOnBlock")
-    private TypedActionResult<ItemStack> preventItemUseIfBlockItem(BlockItem blockItem, World world, PlayerEntity user, Hand hand) {
-        if(user != null) {
-            PowerHolderComponent component = PowerHolderComponent.KEY.get(user);
-            ItemStack stackInHand = user.getStackInHand(hand);
-            for(PreventItemUsePower piup : component.getPowers(PreventItemUsePower.class)) {
-                if(piup.doesPrevent(stackInHand)) {
-                    return TypedActionResult.fail(stackInHand);
-                }
+    //  Prevents the player from 'using' a block item on a block
+    @Inject(method = "useOnBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/BlockItem;use(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/TypedActionResult;"), cancellable = true)
+    private void preventBlockItemUse(ItemUsageContext context, CallbackInfoReturnable<ActionResult> cir) {
+        PlayerEntity playerEntity = context.getPlayer();
+        ItemStack itemStack = context.getStack();
+        if (playerEntity != null) {
+            PowerHolderComponent phc = PowerHolderComponent.KEY.get(playerEntity);
+            if (phc.getPowers(PreventItemUsePower.class).stream().anyMatch(piup -> piup.doesPreventUsage(itemStack))) {
+                cir.setReturnValue(ActionResult.FAIL);
             }
         }
-        return blockItem.use(world, user, hand);
+    }
+
+    //  Prevents the player from placing a block
+    @Inject(method = "canPlace", at = @At("HEAD"), cancellable = true)
+    private void preventBlockItemPlace(ItemPlacementContext context, BlockState state, CallbackInfoReturnable<Boolean> cir) {
+        PlayerEntity playerEntity = context.getPlayer();
+        ItemStack itemStack = context.getStack();
+        if (playerEntity != null) {
+            PowerHolderComponent phc = PowerHolderComponent.KEY.get(playerEntity);
+            if (phc.getPowers(PreventItemUsePower.class).stream().anyMatch(piup -> piup.doesPreventPlacement(itemStack))) {
+                cir.setReturnValue(false);
+            }
+        }
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -73,7 +73,7 @@ public class ItemStackMixin implements MutableItemStack {
             PowerHolderComponent component = PowerHolderComponent.KEY.get(user);
             ItemStack stackInHand = user.getStackInHand(hand);
             for(PreventItemUsePower piup : component.getPowers(PreventItemUsePower.class)) {
-                if(piup.doesPrevent(stackInHand)) {
+                if(piup.doesPreventUsage(stackInHand)) {
                     info.setReturnValue(TypedActionResult.fail(stackInHand));
                     break;
                 }


### PR DESCRIPTION
This PR makes the `prevent_item_use` power type work on preventing 'usage' and 'placement' of block items. It also adds a new `include_block_items` boolean field that has a default value of `false` to keep the initial behavior of the power type