### PR TITLE
EntityGlowPower/SelfGlowPower fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.5
 
 # Mod Properties
-	mod_version = 2.2.1
+	mod_version = 2.2.2
 	maven_group = com.github.apace100
 	archives_base_name = Apoli-1.18
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.5
 
 # Mod Properties
-	mod_version = 2.2.0
+	mod_version = 2.2.1
 	maven_group = com.github.apace100
 	archives_base_name = Apoli-1.18
 

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -1,8 +1,10 @@
 package io.github.apace100.apoli.mixin;
 
+import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.access.MutableItemStack;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.*;
+import io.github.apace100.apoli.util.ApoliConfigClient;
 import io.github.apace100.apoli.util.StackPowerUtil;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.EquipmentSlot;
@@ -12,12 +14,15 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
+import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -27,15 +32,59 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
+import java.util.Locale;
 
 @Mixin(ItemStack.class)
-public class ItemStackMixin implements MutableItemStack {
+public abstract class ItemStackMixin implements MutableItemStack {
 
     @Shadow @Deprecated private Item item;
 
     @Shadow private NbtCompound nbt;
 
     @Shadow private int count;
+
+    @Shadow public abstract UseAction getUseAction();
+
+    @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void addUnusableTooltip(@Nullable PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir, List<Text> list) {
+        if(player != null) {
+            ApoliConfigClient.Tooltips config = ((ApoliConfigClient) Apoli.config).tooltips;
+            if(!config.showUsabilityHints) {
+                return;
+            }
+            List<PreventItemUsePower> powers = PowerHolderComponent.getPowers(player, PreventItemUsePower.class).stream().filter(p -> p.doesPrevent((ItemStack)(Object)this)).toList();
+            int powerCountWithHidden = powers.size();
+            powers = powers.stream().filter(p -> !p.getType().isHidden()).toList();
+            if(powerCountWithHidden == 0) {
+                return;
+            }
+            String translationKeyBase = "tooltip.apoli.unusable." + getUseAction().name().toLowerCase(Locale.ROOT);
+            Formatting textColor = Formatting.GRAY;
+            Formatting powerColor = Formatting.RED;
+            if(config.compactUsabilityHints || powers.size() == 0) {
+                if(powers.size() == 1) {
+                    PreventItemUsePower power = powers.get(0);
+                    MutableText preventText = new TranslatableText(translationKeyBase + ".single",
+                        power.getType().getName().formatted(powerColor)).formatted(textColor);
+                    list.add(preventText);
+                } else {
+                    list.add(
+                        new TranslatableText(translationKeyBase + ".multiple",
+                            new LiteralText((powers.size() == 0 ? powerCountWithHidden : powers.size()) + "").formatted(powerColor))
+                            .formatted(textColor));
+                }
+            } else {
+                MutableText powerNameList = powers.get(0).getType().getName().formatted(powerColor);
+                for(int i = 1; i < powers.size(); i++) {
+                    powerNameList = powerNameList.append(new LiteralText(", ").formatted(textColor));
+                    powerNameList = powerNameList.append(powers.get(i).getType().getName().formatted(powerColor));
+                }
+                MutableText preventText = new TranslatableText(translationKeyBase + ".single",
+                    powerNameList).formatted(textColor);
+                list.add(preventText);
+            }
+        }
+    }
 
     @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;hasNbt()Z", ordinal = 1), locals = LocalCapture.CAPTURE_FAILHARD)
     private void addEquipmentPowerTooltips(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir, List<Text> list) {

--- a/src/main/java/io/github/apace100/apoli/mixin/StatusEffectInstanceMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/StatusEffectInstanceMixin.java
@@ -1,12 +1,13 @@
 package io.github.apace100.apoli.mixin;
 
+import io.github.apace100.apoli.access.HiddenEffectStatus;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(StatusEffectInstance.class)
-public class StatusEffectInstanceMixin {
+public class StatusEffectInstanceMixin implements HiddenEffectStatus {
     @Shadow
     @Nullable
     private StatusEffectInstance hiddenEffect;

--- a/src/main/java/io/github/apace100/apoli/mixin/WorldRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/WorldRendererMixin.java
@@ -34,9 +34,6 @@ public abstract class WorldRendererMixin {
     @Shadow
     private MinecraftClient client;
 
-    @Unique
-    private Entity renderEntity;
-
     @Shadow public abstract void reload();
 
     @Shadow public abstract void render(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f);
@@ -49,28 +46,4 @@ public abstract class WorldRendererMixin {
         }
     }
 
-    @Inject(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/entity/Entity;getTeamColorValue()I"), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void getEntity(MatrixStack matrices, float tickDelta, long var3, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, CallbackInfo ci, Profiler profiler, boolean bl, Vec3d vec3d, double d, double e, double f, Matrix4f matrix4f2, boolean bl2, Frustum frustum, boolean bl4, VertexConsumerProvider.Immediate immediate, Iterator var26, Entity entity) {
-        this.renderEntity = entity;
-    }
-
-    @ModifyArgs(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/OutlineVertexConsumerProvider;setColor(IIII)V"))
-    private void setColors(Args args) {
-        for (EntityGlowPower power : PowerHolderComponent.getPowers(client.getCameraEntity(), EntityGlowPower.class)) {
-            if (power.doesApply(renderEntity)) {
-                if (!power.usesTeams()) {
-                    args.set(0, (int)(power.getRed() * 255.0F));
-                    args.set(1, (int)(power.getGreen() * 255.0F));
-                    args.set(2, (int)(power.getBlue() * 255.0F));
-                }
-            }
-        }
-        for (SelfGlowPower power : PowerHolderComponent.getPowers(renderEntity, SelfGlowPower.class)) {
-            if (!power.usesTeams()) {
-                args.set(0, (int)(power.getRed() * 255.0F));
-                args.set(1, (int)(power.getGreen() * 255.0F));
-                args.set(2, (int)(power.getBlue() * 255.0F));
-            }
-        }
-    }
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/BlockConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/BlockConditions.java
@@ -149,6 +149,7 @@ public class BlockConditions {
                     } else if(data.isPresent("comparison") && data.isPresent("compare_to") && value instanceof Integer) {
                         return ((Comparison)data.get("comparison")).compare((Integer) value, data.getInt("compare_to"));
                     }
+                    return true;
                 }
                 return false;
             }));

--- a/src/main/java/io/github/apace100/apoli/util/ApoliConfigClient.java
+++ b/src/main/java/io/github/apace100/apoli/util/ApoliConfigClient.java
@@ -9,9 +9,18 @@ public class ApoliConfigClient extends ApoliConfig {
     @ConfigEntry.Gui.CollapsibleObject
     public ResourcesAndCooldowns resourcesAndCooldowns = new ResourcesAndCooldowns();
 
+    @ConfigEntry.Gui.CollapsibleObject
+    public Tooltips tooltips = new Tooltips();
+
     public static class ResourcesAndCooldowns {
 
         public int hudOffsetX = 0;
         public int hudOffsetY = 0;
+    }
+
+    public static class Tooltips {
+
+        public boolean showUsabilityHints = true;
+        public boolean compactUsabilityHints = false;
     }
 }

--- a/src/main/resources/assets/apoli/lang/en_us.json
+++ b/src/main/resources/assets/apoli/lang/en_us.json
@@ -39,6 +39,23 @@
 
   "commands.apoli.resource.invalid_entity": "The entity is not a living entity, thus can't have any powers.",
 
+  "tooltip.apoli.unusable.none.single": "Unusable (%s)",
+  "tooltip.apoli.unusable.none.multiple": "Unusable (%s)",
+  "tooltip.apoli.unusable.eat.single": "Inedible (%s)",
+  "tooltip.apoli.unusable.eat.multiple": "Inedible (%s)",
+  "tooltip.apoli.unusable.drink.single": "Undrinkable (%s)",
+  "tooltip.apoli.unusable.drink.multiple": "Undrinkable (%s)",
+  "tooltip.apoli.unusable.block.single": "Unusable (%s)",
+  "tooltip.apoli.unusable.block.multiple": "Unusable (%s)",
+  "tooltip.apoli.unusable.bow.single": "Unusable (%s)",
+  "tooltip.apoli.unusable.bow.multiple": "Unusable (%s)",
+  "tooltip.apoli.unusable.spear.single": "Unusable (%s)",
+  "tooltip.apoli.unusable.spear.multiple": "Unusable (%s)",
+  "tooltip.apoli.unusable.crossbow.single": "Unusable (%s)",
+  "tooltip.apoli.unusable.crossbow.multiple": "Unusable (%s)",
+  "tooltip.apoli.unusable.spyglass.single": "Unusable (%s)",
+  "tooltip.apoli.unusable.spyglass.multiple": "Unusable (%s)",
+
   "text.autoconfig.power_config.title": "Apoli Power Config",
 
   "text.autoconfig.power_config.option.resourcesAndCooldowns": "Resources & Cooldowns",
@@ -47,5 +64,9 @@
 
   "text.autoconfig.power_config.option.executeCommand": "Execute Command",
   "text.autoconfig.power_config.option.executeCommand.permissionLevel": "Permission Level",
-  "text.autoconfig.power_config.option.executeCommand.showOutput": "Show Output in Chat"
+  "text.autoconfig.power_config.option.executeCommand.showOutput": "Show Output in Chat",
+
+  "text.autoconfig.power_config.option.tooltips": "Tooltips",
+  "text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Show Usability Hints",
+  "text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compact Usability Hints"
 }

--- a/testdata/apoli/powers/glow_in_view.json
+++ b/testdata/apoli/powers/glow_in_view.json
@@ -2,5 +2,8 @@
   "type": "apoli:entity_glow",
   "bientity_condition": {
     "type": "apoli:can_see"
-  }
+  },
+  "red": 1.0,
+  "green": 0.0,
+  "blue": 1.0
 }

--- a/testdata/apoli/powers/glow_invisible.json
+++ b/testdata/apoli/powers/glow_invisible.json
@@ -3,5 +3,8 @@
   "entity_condition": {
     "type": "apoli:status_effect",
     "effect": "minecraft:invisibility"
-  }
+  },
+  "red": 1.0,
+  "green": 1.0,
+  "blue": 0.0
 }


### PR DESCRIPTION
Hi there!
I noticed that Apoli used Inject and **LocalCapture** in WorldRendererMixin to realize the function of modifying entity glow colors from powers, which is rather unnecessary and might cause compatibility problems.
So I made a fix which Inject Entity::getTeamColorValue instead :)

It should work fine in most cases as the only call to this method in vanilla is from WorldRenderer::render (which is where the original mixin targets). It may lead to some problems when other mods use this method for certain function, but I believe the potential impact would be far smaller than before.

I also changed the color logic of both powers:
1. If `use_teams` is set to true, custom glowing colors will still work on those entities who don't have a team or whose team doesn't got a team color.
2. Custom glowing colors from different powers will mix with each other, instead of overriding each other "randomly". I changed the test data to test this: While `apoli:glow_in_view`  has a magenta color (1, 0, 1) and `apoli:glow_invisible` has a yellow color (1, 1, 0), having both power will make invisible entities outside player's view glow in pink color(1, 0.5, 0.5).

I'm not sure if the original logic was made with certain consideration, so just ignore my change to the color logic if you dislike it ;)