### PR TITLE
Added `damaging_fall_distance` for ModifyFallingPower

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/LivingEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LivingEntityMixin.java
@@ -354,6 +354,26 @@ public abstract class LivingEntityMixin extends Entity implements ModifiableFood
         return in;
     }
 
+    @ModifyConstant(method = "fall", constant = @Constant(floatValue = 3.0F))
+    private float modifyDamagingFallDistanceClient(float original) {
+        List<ModifyFallingPower> modifyFallingPowers = PowerHolderComponent.getPowers(this, ModifyFallingPower.class);
+        if(modifyFallingPowers.size() > 0) {
+            ModifyFallingPower power = modifyFallingPowers.get(0);
+            return power.damagingFallDistance;
+        }
+        return original;
+    }
+
+    @ModifyVariable(method = "computeFallDamage", at = @At("HEAD"), argsOnly = true, ordinal = 0)
+    private float modifyDamagingFallDistanceServer(float original) {
+        List<ModifyFallingPower> modifyFallingPowers = PowerHolderComponent.getPowers(this, ModifyFallingPower.class);
+        if(modifyFallingPowers.size() > 0) {
+            ModifyFallingPower power = modifyFallingPowers.get(0);
+            return original - power.damagingFallDistance + 3.0F;
+        }
+        return original;
+    }
+
     @ModifyVariable(method = "travel", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/LivingEntity;onGround:Z", opcode = Opcodes.GETFIELD, ordinal = 2))
     private float modifySlipperiness(float original) {
         return PowerHolderComponent.modify(this, ModifySlipperinessPower.class, original, p -> p.doesApply(world, getVelocityAffectingPos()));

--- a/src/main/java/io/github/apace100/apoli/power/ModifyFallingPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyFallingPower.java
@@ -4,26 +4,36 @@ import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.power.factory.PowerFactory;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.block.pattern.CachedBlockPosition;
 import net.minecraft.entity.LivingEntity;
+
+import java.util.function.Predicate;
 
 public class ModifyFallingPower extends Power {
 
     public final double velocity;
     public final boolean takeFallDamage;
+    public final float damagingFallDistance;
 
-    public ModifyFallingPower(PowerType<?> type, LivingEntity entity, double velocity, boolean takeFallDamage) {
+    public ModifyFallingPower(PowerType<?> type, LivingEntity entity, double velocity, boolean takeFallDamage, float damagingFallDistance) {
         super(type, entity);
         this.velocity = velocity;
         this.takeFallDamage = takeFallDamage;
+        this.damagingFallDistance = damagingFallDistance;
     }
 
     public static PowerFactory createFactory() {
         return new PowerFactory<>(Apoli.identifier("modify_falling"),
             new SerializableData()
                 .add("velocity", SerializableDataTypes.DOUBLE)
-                .add("take_fall_damage", SerializableDataTypes.BOOLEAN, true),
+                .add("take_fall_damage", SerializableDataTypes.BOOLEAN, true)
+                .add("damaging_fall_distance", SerializableDataTypes.FLOAT, 3.0F),
             data ->
-                (type, player) -> new ModifyFallingPower(type, player, data.getDouble("velocity"), data.getBoolean("take_fall_damage")))
+                (type, player) -> new ModifyFallingPower(type, player,
+                    data.getDouble("velocity"),
+                    data.getBoolean("take_fall_damage"),
+                    data.getFloat("damaging_fall_distance")
+            ))
             .allowCondition();
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/ModifyFallingPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyFallingPower.java
@@ -4,10 +4,7 @@ import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.power.factory.PowerFactory;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
-import net.minecraft.block.pattern.CachedBlockPosition;
 import net.minecraft.entity.LivingEntity;
-
-import java.util.function.Predicate;
 
 public class ModifyFallingPower extends Power {
 

--- a/testdata/apoli/powers/modify_falling.json
+++ b/testdata/apoli/powers/modify_falling.json
@@ -1,0 +1,5 @@
+{
+  "type": "apoli:modify_falling",
+  "velocity": 0.08,
+  "damaging_fall_distance": 10.0
+}


### PR DESCRIPTION
Added `damaging_fall_distance` field for ModifyFallingPower to control the shortest fall distance for entity to get hurt, in respond to [Origins#507](https://github.com/apace100/origins-fabric/issues/507).
Though it's also possible to change the realize of `take_fall_damage` from (setting `fallDistance` to `0`) to (setting `LivingEntity#computeFallDamage@damageMultiplier` to `0`), I prefer not to change the original logic.