### PR TITLE
Make the `scoreboard` entity condition work for entities and score holders

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
@@ -9,6 +9,7 @@ import io.github.apace100.apoli.mixin.EntityAccessor;
 import io.github.apace100.apoli.power.*;
 import io.github.apace100.apoli.power.factory.condition.entity.ElytraFlightPossibleCondition;
 import io.github.apace100.apoli.power.factory.condition.entity.RaycastCondition;
+import io.github.apace100.apoli.power.factory.condition.entity.ScoreboardCondition;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.apoli.util.Shape;
@@ -301,24 +302,7 @@ public class EntityConditions {
         register(new ConditionFactory<>(Apoli.identifier("entity_type"), new SerializableData()
             .add("entity_type", SerializableDataTypes.ENTITY_TYPE),
             (data, entity) -> entity.getType() == data.get("entity_type")));
-        register(new ConditionFactory<>(Apoli.identifier("scoreboard"), new SerializableData()
-            .add("objective", SerializableDataTypes.STRING)
-            .add("comparison", ApoliDataTypes.COMPARISON)
-            .add("compare_to", SerializableDataTypes.INT),
-            (data, entity) -> {
-                if(entity instanceof PlayerEntity) {
-                    PlayerEntity player = (PlayerEntity)entity;
-                    Scoreboard scoreboard = player.getScoreboard();
-                    ScoreboardObjective objective = scoreboard.getObjective(data.getString("objective"));
-                    String playerName = player.getName().asString();
-
-                    if (scoreboard.playerHasObjective(playerName, objective)) {
-                        int value = scoreboard.getPlayerScore(playerName, objective).getScore();
-                        return ((Comparison)data.get("comparison")).compare(value, data.getInt("compare_to"));
-                    }
-                }
-                return false;
-            }));
+        register(ScoreboardCondition.getFactory());
         register(new ConditionFactory<>(Apoli.identifier("command"), new SerializableData()
             .add("command", SerializableDataTypes.STRING)
             .add("comparison", ApoliDataTypes.COMPARISON)

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/ScoreboardCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/ScoreboardCondition.java
@@ -1,0 +1,44 @@
+package io.github.apace100.apoli.power.factory.condition.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ScoreboardObjective;
+
+public class ScoreboardCondition {
+
+    public static boolean condition(SerializableData.Instance data, Entity entity) {
+
+        String name = data.getString("name");
+        if (name == null) {
+            if (entity instanceof PlayerEntity playerEntity) name = playerEntity.getName().asString();
+            else name = entity.getUuidAsString();
+        }
+
+        Scoreboard scoreboard = entity.world.getScoreboard();
+        ScoreboardObjective scoreboardObjective = scoreboard.getObjective(data.getString("objective"));
+        if (scoreboard.playerHasObjective(name, scoreboardObjective)) {
+            int score = scoreboard.getPlayerScore(name, scoreboardObjective).getScore();
+            return ((Comparison) data.get("comparison")).compare(score, data.getInt("compare_to"));
+        }
+
+        return false;
+    }
+
+    public static ConditionFactory<Entity> getFactory() {
+        return new ConditionFactory<>(Apoli.identifier("scoreboard"),
+            new SerializableData()
+                .add("name", SerializableDataTypes.STRING, null)
+                .add("objective", SerializableDataTypes.STRING)
+                .add("comparison", ApoliDataTypes.COMPARISON)
+                .add("compare_to", SerializableDataTypes.INT),
+            ScoreboardCondition::condition
+        );
+    }
+}


### PR DESCRIPTION
Previously, it was only limited to players even though entities in general can have scores in scoreboard objectives. This PR allows it so it can now be used for entities in general.

Additionally, it adds a new `name` field which has a default value of `null`. It can be used for checking the score of a specific player (or a "fake" player).