### PR TITLE
Optimized glowing and invisibility

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LivingEntityRendererMixin.java
@@ -37,13 +37,14 @@ public abstract class LivingEntityRendererMixin extends EntityRenderer<LivingEnt
             cir.setReturnValue(true);
         }
     }
-
-    @Inject(method = "render", at = @At(value = "HEAD"), cancellable = true)
-    private void preventPumpkinRendering(LivingEntity livingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, CallbackInfo info) {
+    
+    @ModifyVariable(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/LivingEntityRenderer;getRenderLayer(Lnet/minecraft/entity/LivingEntity;ZZZ)Lnet/minecraft/client/render/RenderLayer;"), ordinal = 2)
+    private boolean preventOutlineRendering(boolean original, LivingEntity livingEntity) {
         List<InvisibilityPower> invisibilityPowers = PowerHolderComponent.getPowers(livingEntity, InvisibilityPower.class);
-        if(invisibilityPowers.size() > 0 && invisibilityPowers.stream().noneMatch(InvisibilityPower::shouldRenderArmor)) {
-            info.cancel();
+        if(invisibilityPowers.size() > 0 && invisibilityPowers.stream().noneMatch(InvisibilityPower::shouldRenderOutline)) {
+            return original;
         }
+        return false;
     }
 
     @ModifyVariable(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/VertexConsumerProvider;getBuffer(Lnet/minecraft/client/render/RenderLayer;)Lnet/minecraft/client/render/VertexConsumer;", shift = At.Shift.BEFORE))
@@ -57,7 +58,11 @@ public abstract class LivingEntityRendererMixin extends EntityRenderer<LivingEnt
     }
 
     @Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/feature/FeatureRenderer;render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/entity/Entity;FFFFFF)V"))
-    private void preventFeatureRendering(FeatureRenderer featureRenderer, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, Entity entity, float limbAngle, float limbDistance, float tickDelta, float animationProgress, float headYaw, float headPitch) {
+    private void preventFeatureRendering(FeatureRenderer featureRenderer, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, Entity entity, float limbAngle, float limbDistance, float tickDelta, float animationProgress, float headYaw, float headPitch, LivingEntity livingEntity) {
+        List<InvisibilityPower> invisibilityPowers = PowerHolderComponent.getPowers(livingEntity, InvisibilityPower.class);
+        if(invisibilityPowers.size() > 0 && invisibilityPowers.stream().noneMatch(InvisibilityPower::shouldRenderArmor)) {
+            return;
+        }
         Class cls = featureRenderer.getClass();
         if(!PowerHolderComponent.getPowers(entity, PreventFeatureRenderPower.class).stream().anyMatch(p -> p.doesApply(cls))) {
             featureRenderer.render(matrices, vertexConsumers, light, entity, limbAngle, limbDistance, tickDelta, animationProgress, headYaw, headPitch);

--- a/src/main/java/io/github/apace100/apoli/power/InvisibilityPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/InvisibilityPower.java
@@ -9,22 +9,32 @@ import net.minecraft.entity.LivingEntity;
 public class InvisibilityPower extends Power {
 
     private final boolean renderArmor;
+    private final boolean renderOutline;
 
-    public InvisibilityPower(PowerType<?> type, LivingEntity entity, boolean renderArmor) {
+    public InvisibilityPower(PowerType<?> type, LivingEntity entity, boolean renderArmor, boolean renderOutline) {
         super(type, entity);
         this.renderArmor = renderArmor;
+        this.renderOutline = renderOutline;
     }
 
     public boolean shouldRenderArmor() {
         return renderArmor;
     }
+    
+    public boolean shouldRenderOutline() {
+        return renderOutline;
+    }
 
     public static PowerFactory createFactory() {
         return new PowerFactory<>(Apoli.identifier("invisibility"),
             new SerializableData()
-                .add("render_armor", SerializableDataTypes.BOOLEAN),
+                .add("render_armor", SerializableDataTypes.BOOLEAN, false)
+                .add("render_outline", SerializableDataTypes.BOOLEAN, false),
             data ->
-                (type, player) -> new InvisibilityPower(type, player, data.getBoolean("render_armor")))
+                (type, player) -> new InvisibilityPower(type, player,
+                    data.getBoolean("render_armor"),
+                    data.getBoolean("render_outline")
+                ))
             .allowCondition();
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditionsClient.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditionsClient.java
@@ -1,7 +1,6 @@
 package io.github.apace100.apoli.power.factory.condition;
 
 import io.github.apace100.apoli.Apoli;
-import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.mixin.ClientAdvancementManagerAccessor;
 import io.github.apace100.apoli.mixin.ClientPlayerInteractionManagerAccessor;
 import io.github.apace100.apoli.mixin.ServerPlayerInteractionManagerAccessor;
@@ -16,7 +15,6 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientAdvancementManager;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
@@ -82,6 +80,8 @@ public final class EntityConditionsClient {
             }
             return false;
         }));
+        register(new ConditionFactory<>(Apoli.identifier("glowing"), new SerializableData(),
+            (data, entity) -> MinecraftClient.getInstance().hasOutline(entity)));
     }
 
     private static void register(ConditionFactory<Entity> conditionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditionsServer.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditionsServer.java
@@ -1,15 +1,12 @@
 package io.github.apace100.apoli.power.factory.condition;
 
 import io.github.apace100.apoli.Apoli;
-import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.mixin.ServerPlayerInteractionManagerAccessor;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.calio.data.SerializableData;
-import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.advancement.Advancement;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
@@ -50,6 +47,8 @@ public final class EntityConditionsServer {
             }
             return false;
         }));
+        register(new ConditionFactory<>(Apoli.identifier("glowing"), new SerializableData(),
+            (data, entity) -> entity.isGlowing()));
     }
 
     private static void register(ConditionFactory<Entity> conditionFactory) {

--- a/testdata/apoli/powers/invisible_with_outline.json
+++ b/testdata/apoli/powers/invisible_with_outline.json
@@ -1,0 +1,5 @@
+{
+  "type": "apoli:invisibility",
+  "render_armor": false,
+  "render_outline": true
+}


### PR DESCRIPTION
Related discord suggestion: https://discord.com/channels/734127708488859831/734133482757816401/1013755469304705124
1. Added a new entity condition: `apoli:glowing`, which check if the entity is glowing. This condition would check for visual effects on client (using `Minecraft#hasOutline`) and the actual status of the entity on server (currently using `Entity#isGlowing`, preferable using `Entity#isGlowingLocal` instead?)
2. Added `render_outline` for power `apoli:invisibility`, which specifies whether the glowing outline should be rendered.
3. Changed how `render_armor` works, so it won't cancel the whole method at head and causing the glowing outline not being rendered.
4. Possible improvements: maybe keep the feature of cancelling the whole render method, and leaving it specified in another field, because we might need it to prevent other mods' mixins adding new render effects.
