### PR TITLE
Add a `block_condition` field to `block_collision`

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
@@ -7,6 +7,7 @@ import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.mixin.EntityAccessor;
 import io.github.apace100.apoli.power.*;
+import io.github.apace100.apoli.power.factory.condition.entity.BlockCollisionCondition;
 import io.github.apace100.apoli.power.factory.condition.entity.ElytraFlightPossibleCondition;
 import io.github.apace100.apoli.power.factory.condition.entity.RaycastCondition;
 import io.github.apace100.apoli.power.factory.condition.entity.ScoreboardCondition;
@@ -72,16 +73,7 @@ public class EntityConditions {
             (data, entity) -> ((List<ConditionFactory<Entity>.Instance>)data.get("conditions")).stream().anyMatch(
                 condition -> condition.test(entity)
             )));
-        register(new ConditionFactory<>(Apoli.identifier("block_collision"), new SerializableData()
-            .add("offset_x", SerializableDataTypes.FLOAT)
-            .add("offset_y", SerializableDataTypes.FLOAT)
-            .add("offset_z", SerializableDataTypes.FLOAT),
-            (data, entity) -> entity.world.getBlockCollisions(entity,
-                entity.getBoundingBox().offset(
-                    data.getFloat("offset_x") * entity.getBoundingBox().getXLength(),
-                    data.getFloat("offset_y") * entity.getBoundingBox().getYLength(),
-                    data.getFloat("offset_z") * entity.getBoundingBox().getZLength())
-            ).iterator().hasNext()));
+        register(BlockCollisionCondition.getFactory());
         register(new ConditionFactory<>(Apoli.identifier("brightness"), new SerializableData()
             .add("comparison", ApoliDataTypes.COMPARISON)
             .add("compare_to", SerializableDataTypes.FLOAT),

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/BlockCollisionCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/BlockCollisionCondition.java
@@ -1,0 +1,66 @@
+package io.github.apace100.apoli.power.factory.condition.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.block.pattern.CachedBlockPosition;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+
+import java.util.function.Predicate;
+
+public class BlockCollisionCondition {
+
+    public static boolean condition(SerializableData.Instance data, Entity entity) {
+
+        Box entityBoundingBox = entity.getBoundingBox();
+        Box offsetEntityBoundingBox = entityBoundingBox.offset(
+            data.getFloat("offset_x") * entityBoundingBox.getXLength(),
+            data.getFloat("offset_y") * entityBoundingBox.getYLength(),
+            data.getFloat("offset_z") * entityBoundingBox.getZLength()
+        );
+
+        if (data.isPresent("block_condition")) {
+
+            Predicate<CachedBlockPosition> blockCondition = data.get("block_condition");
+            BlockPos minBlockPos = new BlockPos(offsetEntityBoundingBox.minX + 0.001, offsetEntityBoundingBox.minY + 0.001, offsetEntityBoundingBox.minZ + 0.001);
+            BlockPos maxBlockPos = new BlockPos(offsetEntityBoundingBox.maxX - 0.001, offsetEntityBoundingBox.maxY - 0.001, offsetEntityBoundingBox.maxZ - 0.001);
+            BlockPos.Mutable mutableBlockPos = new BlockPos.Mutable();
+            int matchingBlocks = 0;
+
+            for (int x = minBlockPos.getX(); x <= maxBlockPos.getX(); x++) {
+                for (int y = minBlockPos.getY(); y <= maxBlockPos.getY(); y++) {
+                    for (int z = minBlockPos.getZ(); z <= maxBlockPos.getZ(); z++) {
+                        mutableBlockPos.set(x, y, z);
+                        if (blockCondition.test(new CachedBlockPosition(entity.world, mutableBlockPos, true))) matchingBlocks++;
+                    }
+                }
+            }
+
+            return matchingBlocks > 0;
+
+        }
+
+        else return entity.world
+            .getBlockCollisions(entity, offsetEntityBoundingBox)
+            .iterator()
+            .hasNext();
+
+    }
+
+    public static ConditionFactory<Entity> getFactory() {
+        return new ConditionFactory<>(
+            Apoli.identifier("block_collision"),
+            new SerializableData()
+                .add("block_condition", ApoliDataTypes.BLOCK_CONDITION, null)
+                .add("offset_x", SerializableDataTypes.FLOAT, 0F)
+                .add("offset_y", SerializableDataTypes.FLOAT, 0F)
+                .add("offset_z", SerializableDataTypes.FLOAT, 0F),
+            BlockCollisionCondition::condition
+        );
+    }
+
+}


### PR DESCRIPTION
This PR adds a `block_condition` field to the `block_collision` entity condition type. There used to be an overload for the `CollisionView#getBlockCollisions` method that accepts a `BiPredicate<BlockState, BlockPos>` but that doesn't seem to exist anymore starting from 1.18, so I had to use another way