### PR TITLE
Add a new field to `replace_inventory` and `drop_inventory` entity action types

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/ItemSlotArgumentTypeAccessor.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemSlotArgumentTypeAccessor.java
@@ -10,6 +10,8 @@ import java.util.Map;
 public interface ItemSlotArgumentTypeAccessor {
 
     @Accessor("SLOT_NAMES_TO_SLOT_COMMAND_ID")
-    Map<String, Integer> getSlotNamesToSlotCommandId();
+    static Map<String, Integer> getSlotMappings() {
+        throw new AssertionError();
+    }
 
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ReplaceInventoryAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ReplaceInventoryAction.java
@@ -22,19 +22,25 @@ public class ReplaceInventoryAction {
         InventoryType inventoryType = data.get("inventory_type");
 
         switch (inventoryType) {
-            case INVENTORY:
-                replaceInventory(data, entity, null);
-                break;
-            case POWER:
-                if (!data.isPresent("power") || !(entity instanceof LivingEntity livingEntity)) return;
+            case INVENTORY -> replaceInventory(data, entity, null);
+            case POWER -> {
 
-                PowerType<?> targetPowerType = data.get("power");
-                Power targetPower = PowerHolderComponent.KEY.get(livingEntity).getPower(targetPowerType);
+                if (!data.isPresent("power")) return;
+                PowerHolderComponent.KEY.maybeGet(entity).ifPresent(
+                    powerHolderComponent -> {
 
-                if (!(targetPower instanceof InventoryPower inventoryPower)) return;
-                replaceInventory(data, livingEntity, inventoryPower);
-                break;
+                        PowerType<?> targetPowerType = data.get("power");
+                        Power targetPower = powerHolderComponent.getPower(targetPowerType);
+                        if (!(targetPower instanceof InventoryPower inventoryPower)) return;
+
+                        replaceInventory(data, entity, inventoryPower);
+
+                    }
+                );
+
+            }
         }
+
     }
 
     public static ActionFactory<Entity> getFactory() {
@@ -47,8 +53,10 @@ public class ReplaceInventoryAction {
                 .add("slots", ApoliDataTypes.ITEM_SLOTS, null)
                 .add("slot", ApoliDataTypes.ITEM_SLOT, null)
                 .add("power", ApoliDataTypes.POWER_TYPE, null)
-                .add("stack", SerializableDataTypes.ITEM_STACK),
+                .add("stack", SerializableDataTypes.ITEM_STACK)
+                .add("merge_nbt", SerializableDataTypes.BOOLEAN, false),
             ReplaceInventoryAction::action
         );
     }
+
 }

--- a/src/main/java/io/github/apace100/apoli/util/InventoryUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/InventoryUtil.java
@@ -59,33 +59,38 @@ public class InventoryUtil {
         Predicate<ItemStack> itemCondition = data.get("item_condition");
         ActionFactory<Pair<World, ItemStack>>.Instance itemAction = data.get("item_action");
 
-        if (inventoryPower == null) {
-            for (Integer slot : slots) {
+        if (inventoryPower == null) slots.forEach(
+            slot -> {
+
                 StackReference stackReference = entity.getStackReference(slot);
-                if (stackReference != StackReference.EMPTY) {
-                    ItemStack currentItemStack = stackReference.get();
-                    if (!currentItemStack.isEmpty()) {
-                        if (itemCondition == null || itemCondition.test(currentItemStack)) {
-                            if (entityAction != null) entityAction.accept(entity);
-                            itemAction.accept(new Pair<>(entity.world, currentItemStack));
-                        }
-                    }
-                }
+                if (stackReference == StackReference.EMPTY) return;
+
+                ItemStack itemStack = stackReference.get();
+                if (itemStack.isEmpty()) return;
+
+                if (!(itemCondition == null || itemCondition.test(itemStack))) return;
+
+                if (entityAction != null) entityAction.accept(entity);
+                itemAction.accept(new Pair<>(entity.world, itemStack));
+
             }
-        }
+        );
 
         else {
-            slots.removeIf(slot -> slot > inventoryPower.size());
-            for (int i = 0; i < inventoryPower.size(); i++) {
-                if (!slots.isEmpty() && !slots.contains(i)) continue;
-                ItemStack currentItemStack = inventoryPower.getStack(i);
-                if (!currentItemStack.isEmpty()) {
-                    if (itemCondition == null || itemCondition.test(currentItemStack)) {
-                        if (entityAction != null) entityAction.accept(entity);
-                        itemAction.accept(new Pair<>(entity.world, currentItemStack));
-                    }
+            slots.removeIf(slot -> slot < 0 || slot >= inventoryPower.size());
+            slots.forEach(
+                slot -> {
+
+                    ItemStack itemStack = inventoryPower.getStack(slot);
+                    if (itemStack.isEmpty()) return;
+
+                    if (!(itemCondition == null || itemCondition.test(itemStack))) return;
+
+                    if (entityAction != null) entityAction.accept(entity);
+                    itemAction.accept(new Pair<>(entity.world, itemStack));
+
                 }
-            }
+            );
         }
 
     }

--- a/src/main/java/io/github/apace100/apoli/util/InventoryUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/InventoryUtil.java
@@ -5,7 +5,6 @@ import io.github.apace100.apoli.power.InventoryPower;
 import io.github.apace100.apoli.power.factory.action.ActionFactory;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.util.ArgumentWrapper;
-import net.minecraft.command.argument.ItemSlotArgumentType;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -16,7 +15,10 @@ import net.minecraft.util.Pair;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -28,27 +30,16 @@ public class InventoryUtil {
     }
 
     public static Set<Integer> getSlots(SerializableData.Instance data) {
+
         Set<Integer> slots = new HashSet<>();
 
-        if (data.isPresent("slots")) {
-            List<ArgumentWrapper<Integer>> slotArgumentTypes = data.get("slots");
-            for (ArgumentWrapper<Integer> slotArgumentType : slotArgumentTypes) {
-                slots.add(slotArgumentType.get());
-            }
-        }
+        data.<ArgumentWrapper<Integer>>ifPresent("slot", iaw -> slots.add(iaw.get()));
+        data.<List<ArgumentWrapper<Integer>>>ifPresent("slots", iaws -> slots.addAll(iaws.stream().map(ArgumentWrapper::get).toList()));
 
-        if (data.isPresent("slot")) {
-            ArgumentWrapper<Integer> slotArgumentType = data.get("slot");
-            slots.add(slotArgumentType.get());
-        }
-
-        if (slots.isEmpty()) {
-            ItemSlotArgumentType itemSlotArgumentType = new ItemSlotArgumentType();
-            Map<String, Integer> slotNamesWithId = ((ItemSlotArgumentTypeAccessor) itemSlotArgumentType).getSlotNamesToSlotCommandId();
-            slots.addAll(slotNamesWithId.values());
-        }
+        if (slots.isEmpty()) slots.addAll(ItemSlotArgumentTypeAccessor.getSlotMappings().values());
 
         return slots;
+
     }
 
     public static void modifyInventory(SerializableData.Instance data, Entity entity, InventoryPower inventoryPower) {
@@ -264,7 +255,7 @@ public class InventoryUtil {
             float l = 0.02F * random.nextFloat();
             itemEntity.setVelocity(
                 (double) (- i * h * f) + Math.cos(k) * (double) l,
-                -g * f + 0.1F + (random.nextFloat() - random.nextFloat()) * 0.1F,
+                (-g * f + 0.1F + (random.nextFloat() - random.nextFloat()) * 0.1F),
                 (double) (j * h * f) + Math.sin(k) * (double) l
             );
         }


### PR DESCRIPTION
This PR adds a new field to the `replace_inventory` and `drop_inventory` entity action types: `merge_nbt` boolean field and the `amount` integer field respectively. 

* The new `merge_nbt` boolean field in the `replace_inventory` entity action type determines if the NBT of the affected item stack should be merged with the NBT of the replacement item stack; it has a default value of `false`.
* The new `amount` integer field in the `drop_inventory` entity action type determines how many of the affected items should be dropped; it has a default value of `0`, which indicates that all items will be dropped.

This PR also changes the accessor for the `SLOT_NAMES_TO_SLOT_COMMAND_ID` map in `ItemSlotArgumentType` to a static method, as it should have been *(oops).* This change should get rid of this message that can be found in the logs:
```
[XX:XX:XX] [main/INFO]: apoli.mixins.json:ItemSlotArgumentTypeAccessor from mod apoli->@Accessor[FIELD_GETTER]::getSlotNamesToSlotCommandId()Ljava/util/Map; should be static as its target is
```