### PR TITLE
Add equals and hashCode methods to Active.Key

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/Active.java
+++ b/src/main/java/io/github/apace100/apoli/power/Active.java
@@ -1,5 +1,7 @@
 package io.github.apace100.apoli.power;
 
+import java.util.Objects;
+
 public interface Active {
 
     void onUse();
@@ -10,5 +12,21 @@ public interface Active {
 
         public String key = "none";
         public boolean continuous = false;
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (obj == this)
+                return true;
+
+            if (!(obj instanceof Active.Key otherKey))
+                return false;
+
+            return otherKey.key.equals(this.key) && otherKey.continuous == this.continuous;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.key, this.continuous);
+        }
     }
 }


### PR DESCRIPTION
This would be **very** useful for anything that compares Active.Key classes. For example Apugli's `key_pressed` entity condition.