### PR TITLE
Update SpawnParticlesAction

### DIFF
--- a/src/main/java/io/github/apace100/apoli/networking/ModPackets.java
+++ b/src/main/java/io/github/apace100/apoli/networking/ModPackets.java
@@ -20,5 +20,7 @@ public class ModPackets {
 
     public static final Identifier SET_ATTACKER = Apoli.identifier("set_attacker");
 
+    public static final Identifier SEND_PARTICLES = Apoli.identifier("send_particles");
+
     public static final Identifier SYNC_STATUS_EFFECT = Apoli.identifier("sync_status_effect");
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/SpawnParticlesAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/SpawnParticlesAction.java
@@ -61,16 +61,13 @@ public class SpawnParticlesAction {
         buf.writeInt(count);
 
         for (int j = 0; j < world.getPlayers().size(); ++j) {
-            ServerPlayerEntity serverPlayerEntity = world.getPlayers().get(j);
-            sendToPlayerIfNearby(world, serverPlayerEntity, force, x, y, z, buf);
-        }
-    }
+            ServerPlayerEntity player = world.getPlayers().get(j);
 
-    private static void sendToPlayerIfNearby(ServerWorld world, ServerPlayerEntity player, boolean force, double x, double y, double z, PacketByteBuf buf) {
-        if (player.getWorld() != world) return;
-        BlockPos blockPos = player.getBlockPos();
-        if (blockPos.isWithinDistance(new Vec3d(x, y, z), force ? 512.0 : 32.0)) {
-            ServerPlayNetworking.send(player, ModPackets.SEND_PARTICLES, buf);
+            if (player.getWorld() != world) return;
+            BlockPos blockPos = player.getBlockPos();
+            if (blockPos.isWithinDistance(new Vec3d(x, y, z), force ? 512.0 : 32.0)) {
+                ServerPlayNetworking.send(player, ModPackets.SEND_PARTICLES, buf);
+            }
         }
     }
 

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/SpawnParticlesAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/SpawnParticlesAction.java
@@ -1,15 +1,23 @@
 package io.github.apace100.apoli.power.factory.action.entity;
 
 import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.networking.ModPackets;
 import io.github.apace100.apoli.power.factory.action.ActionFactory;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
+import io.netty.buffer.Unpooled;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.particle.ParticleEffect;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 
-public class SpawnParticlesAction {
+import java.util.Optional;
 
+public class SpawnParticlesAction {
     public static void action(SerializableData.Instance data, Entity entity) {
         if(entity.world.isClient) {
             return;
@@ -18,25 +26,65 @@ public class SpawnParticlesAction {
         int count = data.get("count");
         if(count <= 0)
             return;
+        boolean force = data.get("force");
         float speed = data.get("speed");
         Vec3d spread = data.get("spread");
         float deltaX = (float) (entity.getWidth() * spread.x);
         float deltaY = (float) (entity.getHeight() * spread.y);
         float deltaZ = (float) (entity.getWidth() * spread.z);
         float offsetY = entity.getHeight() * data.getFloat("offset_y");
-        serverWorld.spawnParticles(data.get("particle"), entity.getX(), entity.getY() + offsetY, entity.getZ(), count, deltaX, deltaY, deltaZ, speed);
+        Vec3d velocity = data.get("velocity");
+
+        sendVelocityParticlePacket(serverWorld, data.get("particle"), force, entity.getX(), entity.getY() + offsetY, entity.getZ(), deltaX, deltaY, deltaZ, Optional.ofNullable(velocity), speed, count);
+    }
+
+    private static void sendVelocityParticlePacket(ServerWorld world, ParticleEffect effect, boolean force, double x, double y, double z, float offsetX, float offsetY, float offsetZ, Optional<Vec3d> velocity, float speed, int count) {
+        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+        SerializableDataTypes.PARTICLE_EFFECT.send(buf, effect);
+        buf.writeBoolean(force);
+
+        buf.writeDouble(x);
+        buf.writeDouble(y);
+        buf.writeDouble(z);
+
+        buf.writeFloat(offsetX);
+        buf.writeFloat(offsetY);
+        buf.writeFloat(offsetZ);
+
+        buf.writeBoolean(velocity.isPresent());
+        velocity.ifPresentOrElse((Vec3d vec3d) -> {
+            buf.writeDouble(vec3d.x);
+            buf.writeDouble(vec3d.y);
+            buf.writeDouble(vec3d.z);
+        }, () -> buf.writeFloat(speed));
+
+        buf.writeInt(count);
+
+        for (int j = 0; j < world.getPlayers().size(); ++j) {
+            ServerPlayerEntity serverPlayerEntity = world.getPlayers().get(j);
+            sendToPlayerIfNearby(world, serverPlayerEntity, force, x, y, z, buf);
+        }
+    }
+
+    private static void sendToPlayerIfNearby(ServerWorld world, ServerPlayerEntity player, boolean force, double x, double y, double z, PacketByteBuf buf) {
+        if (player.getWorld() != world) return;
+        BlockPos blockPos = player.getBlockPos();
+        if (blockPos.isWithinDistance(new Vec3d(x, y, z), force ? 512.0 : 32.0)) {
+            ServerPlayNetworking.send(player, ModPackets.SEND_PARTICLES, buf);
+        }
     }
 
     public static ActionFactory<Entity> getFactory() {
         return new ActionFactory<>(Apoli.identifier("spawn_particles"),
-            new SerializableData()
-                .add("particle", SerializableDataTypes.PARTICLE_EFFECT_OR_TYPE)
-                .add("count", SerializableDataTypes.INT)
-                .add("speed", SerializableDataTypes.FLOAT, 0.0F)
-                .add("force", SerializableDataTypes.BOOLEAN, false)
-                .add("spread", SerializableDataTypes.VECTOR, new Vec3d(0.5, 0.25, 0.5))
-                .add("offset_y", SerializableDataTypes.FLOAT, 0.5F),
-            SpawnParticlesAction::action
+                new SerializableData()
+                        .add("particle", SerializableDataTypes.PARTICLE_EFFECT_OR_TYPE)
+                        .add("count", SerializableDataTypes.INT)
+                        .add("speed", SerializableDataTypes.FLOAT, 0.0F)
+                        .add("force", SerializableDataTypes.BOOLEAN, false)
+                        .add("velocity", SerializableDataTypes.VECTOR, null)
+                        .add("spread", SerializableDataTypes.VECTOR, new Vec3d(0.5, 0.25, 0.5))
+                        .add("offset_y", SerializableDataTypes.FLOAT, 0.5F),
+                io.github.apace100.apoli.power.factory.action.entity.SpawnParticlesAction::action
         );
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/SpawnParticlesAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/SpawnParticlesAction.java
@@ -35,10 +35,10 @@ public class SpawnParticlesAction {
         float offsetY = entity.getHeight() * data.getFloat("offset_y");
         Vec3d velocity = data.get("velocity");
 
-        sendVelocityParticlePacket(serverWorld, data.get("particle"), force, entity.getX(), entity.getY() + offsetY, entity.getZ(), deltaX, deltaY, deltaZ, Optional.ofNullable(velocity), speed, count);
+        sendParticlePacket(serverWorld, data.get("particle"), force, entity.getX(), entity.getY() + offsetY, entity.getZ(), deltaX, deltaY, deltaZ, Optional.ofNullable(velocity), speed, count);
     }
 
-    private static void sendVelocityParticlePacket(ServerWorld world, ParticleEffect effect, boolean force, double x, double y, double z, float offsetX, float offsetY, float offsetZ, Optional<Vec3d> velocity, float speed, int count) {
+    private static void sendParticlePacket(ServerWorld world, ParticleEffect effect, boolean force, double x, double y, double z, float offsetX, float offsetY, float offsetZ, Optional<Vec3d> velocity, float speed, int count) {
         PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
         SerializableDataTypes.PARTICLE_EFFECT.send(buf, effect);
         buf.writeBoolean(force);

--- a/testdata/apoli/powers/spawn_particles.json
+++ b/testdata/apoli/powers/spawn_particles.json
@@ -1,0 +1,14 @@
+{
+  "type": "apoli:action_over_time",
+  "interval": 1,
+  "entity_action": {
+    "type": "apoli:spawn_particles",
+    "particle": {
+      "type": "minecraft:entity_effect"
+    },
+    "count": 1,
+    "velocity": {
+      "x": 1.0
+    }
+  }
+}


### PR DESCRIPTION
# This might want to be merged alongside #58 alongside these changes reflecting this over there too.

## So what have I changed?
`force` field now actually works.
Added new `velocity` field. A Vec3d that specifies the exact velocity that the particle will move in within each direction. This was added due to specific particle effects (such as `minecraft:entity_effect` and `minecraft:note`) changing their color based on x, y and z velocity.

I've had to recreate Minecraft's ParticleS2CPacket (yarn mappings) logic for this change to be made, which may not be the best idea.