### PR TITLE
Fix incorrect maths used in Add Velocity action

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx1G
     loader_version=0.14.12
 
 # Mod Properties
-    mod_version = 2.7.0
+    mod_version = 2.7.1
     maven_group = com.github.apace100
     archives_base_name = Apoli-1.19.3
 

--- a/src/main/java/io/github/apace100/apoli/util/Space.java
+++ b/src/main/java/io/github/apace100/apoli/util/Space.java
@@ -81,7 +81,7 @@ public enum Space {
             Matrix3f transformMatrix = getBaseTransformMatrixFromNormalizedDirectionVector(normalizedBase, baseYaw);
             if (!normalizeBase) // if the base wasn't supposed to get normalized, re-scale to compensate for the prior normalization
                 transformMatrix.scale(baseScale, baseScale, baseScale);
-            vector.mul(transformMatrix); // matrix multiplication, vector is now in the new base :D
+            vector.mulTranspose(transformMatrix); // matrix multiplication, vector is now in the new base :D
         }
     }
 


### PR DESCRIPTION
Fixed the incorrect maths done in io.github.apace100.apoli.Space::transformVectorToBase which caused the Add Velocity action to launch the target in the wrong direction.

Bumped version to 2.7.1.