### PR TITLE
Implemented Factory Interface

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,4 @@
-before_install:
-  - wget https://github.com/sormuras/bach/raw/releases/11/install-jdk.sh
-  - source install-jdk.sh --feature 17
+jdk:
+  - openjdk17
 env:
   ENVIRONMENT: "production"

--- a/src/main/java/io/github/apace100/apoli/power/factory/Factory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/Factory.java
@@ -1,9 +1,12 @@
 package io.github.apace100.apoli.power.factory;
 
+import io.github.apace100.calio.data.SerializableData;
 import net.minecraft.util.Identifier;
 
 public interface Factory {
 
     Identifier getSerializerId();
+
+    SerializableData getSerializableData();
 
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/Factory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/Factory.java
@@ -1,7 +1,5 @@
 package io.github.apace100.apoli.power.factory;
 
-import com.google.gson.JsonObject;
-import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
 
 public interface Factory {

--- a/src/main/java/io/github/apace100/apoli/power/factory/Factory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/Factory.java
@@ -1,0 +1,11 @@
+package io.github.apace100.apoli.power.factory;
+
+import com.google.gson.JsonObject;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+
+public interface Factory {
+
+    Identifier getSerializerId();
+
+}

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactory.java
@@ -14,7 +14,7 @@ import net.minecraft.util.Identifier;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-public class PowerFactory<P extends Power> {
+public class PowerFactory<P extends Power> implements Factory {
 
     private final Identifier id;
     private boolean hasConditions = false;
@@ -35,6 +35,7 @@ public class PowerFactory<P extends Power> {
         return this;
     }
 
+    @Override
     public Identifier getSerializerId() {
         return id;
     }

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactory.java
@@ -40,6 +40,11 @@ public class PowerFactory<P extends Power> implements Factory {
         return id;
     }
 
+    @Override
+    public SerializableData getSerializableData() {
+        return data;
+    }
+
     public class Instance implements BiFunction<PowerType<P>, LivingEntity, P> {
 
         private final SerializableData.Instance dataInstance;

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/ActionFactory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/ActionFactory.java
@@ -49,6 +49,12 @@ public class ActionFactory<T> implements Factory {
         return identifier;
     }
 
+
+    @Override
+    public SerializableData getSerializableData() {
+        return data;
+    }
+
     public Instance read(JsonObject json) {
         return new Instance(data.read(json));
     }

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/ActionFactory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/ActionFactory.java
@@ -1,16 +1,18 @@
 package io.github.apace100.apoli.power.factory.action;
 
 import com.google.gson.JsonObject;
+import io.github.apace100.apoli.power.factory.Factory;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public class ActionFactory<T> {
+public class ActionFactory<T> implements Factory {
 
     private final Identifier identifier;
     protected SerializableData data;
@@ -42,6 +44,7 @@ public class ActionFactory<T> {
         }
     }
 
+    @Override
     public Identifier getSerializerId() {
         return identifier;
     }

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/ConditionFactory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/ConditionFactory.java
@@ -55,6 +55,11 @@ public class ConditionFactory<T> implements Factory {
         return identifier;
     }
 
+    @Override
+    public SerializableData getSerializableData() {
+        return data;
+    }
+
     public Instance read(JsonObject json) {
         return new Instance(data.read(json));
     }

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/ConditionFactory.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/ConditionFactory.java
@@ -1,6 +1,7 @@
 package io.github.apace100.apoli.power.factory.condition;
 
 import com.google.gson.JsonObject;
+import io.github.apace100.apoli.power.factory.Factory;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.network.PacketByteBuf;
@@ -9,7 +10,7 @@ import net.minecraft.util.Identifier;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
-public class ConditionFactory<T> {
+public class ConditionFactory<T> implements Factory {
 
     private final Identifier identifier;
     protected SerializableData data;
@@ -49,6 +50,7 @@ public class ConditionFactory<T> {
         }
     }
 
+    @Override
     public Identifier getSerializerId() {
         return identifier;
     }


### PR DESCRIPTION
This is a relatively small PR, all it does is extract `PowerFactory#getSerializerId()`, `ActionFactory#getSerializerId()` and `ConditionFactory#getSerializerId()` to a Factory interface that those factory classes implement. This is so that you can call the method without needing to cast or specify what type of factory you are using, which is useful in my automatic documentation addon.