### PR TITLE
Add custom metadata for overriding Lithium's `mixin.entity.collisions.suffocation` rule

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -46,6 +46,9 @@
     ],
     "modmenu": {
       "badges": ["library"]
+    },
+    "lithium:options": {
+      "mixin.entity.collisions.suffocation": false
     }
   },
 


### PR DESCRIPTION
This PR adds custom metadata to Apoli to override Lithium's `mixin.entity.collisions.suffocation` optimization rule if Lithium is present. This is a quick-fix for the issue where the `phasing` power type suffocates the entity when phasing through blocks.