### PR TITLE
Bugfixed Invisibility Power render_outline

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LivingEntityRendererMixin.java
@@ -37,14 +37,14 @@ public abstract class LivingEntityRendererMixin extends EntityRenderer<LivingEnt
             cir.setReturnValue(true);
         }
     }
-    
-    @ModifyVariable(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/entity/LivingEntityRenderer;getRenderLayer(Lnet/minecraft/entity/LivingEntity;ZZZ)Lnet/minecraft/client/render/RenderLayer;"), ordinal = 2)
+
+    @ModifyVariable(method = "render", at = @At(value = "STORE"), ordinal = 2)
     private boolean preventOutlineRendering(boolean original, LivingEntity livingEntity) {
         List<InvisibilityPower> invisibilityPowers = PowerHolderComponent.getPowers(livingEntity, InvisibilityPower.class);
         if(invisibilityPowers.size() > 0 && invisibilityPowers.stream().noneMatch(InvisibilityPower::shouldRenderOutline)) {
-            return original;
+            return false;
         }
-        return false;
+        return original;
     }
 
     @ModifyVariable(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/VertexConsumerProvider;getBuffer(Lnet/minecraft/client/render/RenderLayer;)Lnet/minecraft/client/render/VertexConsumer;", shift = At.Shift.BEFORE))

--- a/testdata/apoli/powers/invisible_without_outline.json
+++ b/testdata/apoli/powers/invisible_without_outline.json
@@ -1,7 +1,7 @@
 {
   "type": "apoli:invisibility",
-  "render_armor": false,
-  "render_outline": true,
+  "render_armor": true,
+  "render_outline": false,
   "condition": {
     "type": "apoli:glowing"
   }


### PR DESCRIPTION
This PR bug fixes an issue where the glowing outline still renders even when the invisibility power's render_outline is set to false.

Added testdata power `invisible_without_outline`
Modified testdata power `invisible_with_outline`