### PR TITLE
Add Advancement Grant and Advancement Revoke Entity Action Types

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -2,6 +2,7 @@ package io.github.apace100.apoli.power.factory;
 
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.power.*;
+import io.github.apace100.apoli.power.factory.action.entity.GrantAdvancementAction;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.ladysnake.pal.VanillaAbilities;

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
@@ -454,6 +454,8 @@ public class EntityActions {
         register(ModifyDeathTicksAction.getFactory());
         register(ModifyResourceAction.getFactory());
         register(ModifyStatAction.getFactory());
+        register(GrantAdvancementAction.getFactory());
+        register(RevokeAdvancementAction.getFactory());
     }
 
     private static void register(ActionFactory<Entity> actionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/GrantAdvancementAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/GrantAdvancementAction.java
@@ -1,0 +1,41 @@
+package io.github.apace100.apoli.power.factory.action.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.advancement.Advancement;
+import net.minecraft.advancement.AdvancementProgress;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+public class GrantAdvancementAction {
+
+    public static void action(SerializableData.Instance data, Entity entity) {
+        if (entity instanceof ServerPlayerEntity player) {
+            Identifier id = data.getId("advancement");
+            if (player.getServer() != null) {
+                Advancement adv = player.getServer().getAdvancementLoader().get(id);
+                grant(player, adv);
+            }
+        }
+    }
+
+    public static ActionFactory<Entity> getFactory() {
+        return new ActionFactory<>(Apoli.identifier("grant_advancement"),
+                new SerializableData()
+                        .add("advancement", SerializableDataTypes.IDENTIFIER),
+                GrantAdvancementAction::action
+        );
+    }
+
+    private static void grant(ServerPlayerEntity player, Advancement advancement) {
+        AdvancementProgress advancementProgress = player.getAdvancementTracker().getProgress(advancement);
+        if (!advancementProgress.isDone()) {
+            for (String criterion : advancementProgress.getUnobtainedCriteria()) {
+                player.getAdvancementTracker().grantCriterion(advancement, criterion);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/RevokeAdvancementAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/RevokeAdvancementAction.java
@@ -1,0 +1,41 @@
+package io.github.apace100.apoli.power.factory.action.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.advancement.Advancement;
+import net.minecraft.advancement.AdvancementProgress;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+public class RevokeAdvancementAction {
+
+    public static void action(SerializableData.Instance data, Entity entity) {
+        if (entity instanceof ServerPlayerEntity player) {
+            Identifier id = data.getId("advancement");
+            if (player.getServer() != null) {
+                Advancement adv = player.getServer().getAdvancementLoader().get(id);
+                revoke(player, adv);
+            }
+        }
+    }
+
+    public static ActionFactory<Entity> getFactory() {
+        return new ActionFactory<>(Apoli.identifier("revoke_advancement"),
+                new SerializableData()
+                        .add("advancement", SerializableDataTypes.IDENTIFIER),
+                RevokeAdvancementAction::action
+        );
+    }
+
+    private static void revoke(ServerPlayerEntity player, Advancement advancement) {
+        AdvancementProgress advancementProgress = player.getAdvancementTracker().getProgress(advancement);
+        if (advancementProgress.isAnyObtained()) {
+            for (String string : advancementProgress.getObtainedCriteria()) {
+                player.getAdvancementTracker().revokeCriterion(advancement, string);
+            }
+        }
+    }
+}

--- a/testdata/apoli/powers/grant_advancement.json
+++ b/testdata/apoli/powers/grant_advancement.json
@@ -1,0 +1,12 @@
+{
+  "comment": "Grants an advancment.",
+
+  "type": "apoli:active_self",
+  "entity_action": {
+    "type": "apoli:grant_advancement",
+    "advancement": "minecraft:adventure/arbalistic"
+  },
+  "key": {
+    "key": "key.pickItem"
+  }
+}

--- a/testdata/apoli/powers/revoke_advancement.json
+++ b/testdata/apoli/powers/revoke_advancement.json
@@ -1,0 +1,12 @@
+{
+  "comment": "Revokes an advancment.",
+
+  "type": "apoli:active_self",
+  "entity_action": {
+    "type": "apoli:revoke_advancement",
+    "advancement": "minecraft:adventure/arbalistic"
+  },
+  "key": {
+    "key": "key.pickItem"
+  }
+}


### PR DESCRIPTION
Add `apoli:grant_advancement` and `apoli:revoke_advancement`, along with subsequent Test Data Powers.

The main reason for this is because of origin upgrades in Origins, and also for advancement-triggers in datapacks for any other mods that make use of Apoli. As far as i know, the `apoli:execute_command` entity action is gone (i may be wrong though, i stopped tracking apoli a while back), so this restores that functionality. Even if it isn't, commands are slightly slower if i remember correctly, and this offers a slightly faster alternative.

The entity actions work exactly as you would expect, taking in one argument for the advancement id; here are some example usages: (however you can find test powers in `testdata/grant_advancement.json` and `testdata/revoke_advancement.json`)
```
"entity_action": {
    "type": "apoli:grant_advancement",
    "advancement": "minecraft:adventure/arbalistic"
}
```
```
"entity_action": {
    "type": "apoli:revoke_advancement",
    "advancement": "minecraft:adventure/arbalistic"
}
```