### PR TITLE
Add `selector_action` entity action type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
+++ b/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
@@ -21,6 +21,8 @@ import io.github.apace100.calio.util.ArgumentWrapper;
 import io.github.ladysnake.pal.Pal;
 import io.github.ladysnake.pal.PlayerAbility;
 import net.minecraft.block.pattern.CachedBlockPosition;
+import net.minecraft.command.EntitySelector;
+import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.command.argument.ItemSlotArgumentType;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
@@ -233,6 +235,8 @@ public class ApoliDataTypes {
                     "break", Explosion.DestructionType.DESTROY,
                     "destroy", Explosion.DestructionType.DESTROY_WITH_DECAY)
             ));
+
+    public static final SerializableDataType<ArgumentWrapper<EntitySelector>> ENTITIES_SELECTOR = SerializableDataType.argumentType(EntityArgumentType.entities());
 
     public static <T> SerializableDataType<ConditionFactory<T>.Instance> condition(Class<ConditionFactory<T>.Instance> dataClass, ConditionType<T> conditionType) {
         return new SerializableDataType<>(dataClass, conditionType::write, conditionType::read, conditionType::read);

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/EntityActions.java
@@ -454,6 +454,7 @@ public class EntityActions {
         register(ModifyDeathTicksAction.getFactory());
         register(ModifyResourceAction.getFactory());
         register(ModifyStatAction.getFactory());
+        register(SelectorAction.getFactory());
     }
 
     private static void register(ActionFactory<Entity> actionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/SelectorAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/SelectorAction.java
@@ -1,0 +1,65 @@
+package io.github.apace100.apoli.power.factory.action.entity;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.util.ArgumentWrapper;
+import net.minecraft.command.EntitySelector;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.CommandOutput;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Pair;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public class SelectorAction {
+
+    public static void action(SerializableData.Instance data, Entity entity) {
+
+        MinecraftServer server = entity.world.getServer();
+        if (server == null) return;
+
+        EntitySelector selector = data.<ArgumentWrapper<EntitySelector>>get("selector").get();
+        Predicate<Pair<Entity, Entity>> biEntityCondition = data.get("bientity_condition");
+        Consumer<Pair<Entity, Entity>> biEntityAction = data.get("bientity_action");
+
+        ServerCommandSource source = new ServerCommandSource(
+            CommandOutput.DUMMY,
+            entity.getPos(),
+            entity.getRotationClient(),
+            (ServerWorld) entity.world,
+            2,
+            entity.getEntityName(),
+            entity.getName(),
+            server,
+            entity
+        );
+
+        try {
+            selector.getEntities(source)
+                .stream()
+                .filter(e -> biEntityCondition == null || biEntityCondition.test(new Pair<>(entity, e)))
+                .forEach(e -> biEntityAction.accept(new Pair<>(entity, e)));
+        }
+
+        catch (CommandSyntaxException ignored) {}
+
+    }
+
+    public static ActionFactory<Entity> getFactory() {
+        return new ActionFactory<>(
+            Apoli.identifier("selector_action"),
+            new SerializableData()
+                .add("selector", ApoliDataTypes.ENTITIES_SELECTOR)
+                .add("bientity_action", ApoliDataTypes.BIENTITY_ACTION)
+                .add("bientity_condition", ApoliDataTypes.BIENTITY_CONDITION, null),
+            SelectorAction::action
+        );
+    }
+
+}


### PR DESCRIPTION
This PR adds the [`selector_action` entity action type](https://eggolib.github.io/latest/types/entity_action_types/selector_action) from eggolib, which can execute a bi-entity action on the invoker of the action (actor) and the entities that the specified target selector selects (target)