### PR TITLE
Make the `enchantment` field in the `enchantment` item condition type optional

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/ItemConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/ItemConditions.java
@@ -2,6 +2,7 @@ package io.github.apace100.apoli.power.factory.condition;
 
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.item.EnchantmentCondition;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.apoli.util.StackPowerUtil;
@@ -66,14 +67,7 @@ public class ItemConditions {
                 }
                 return ((Comparison)data.get("comparison")).compare(harvestLevel, data.getInt("compare_to"));
             }));
-        register(new ConditionFactory<>(Apoli.identifier("enchantment"), new SerializableData()
-            .add("enchantment", SerializableDataTypes.ENCHANTMENT)
-            .add("compare_to", SerializableDataTypes.INT)
-            .add("comparison", ApoliDataTypes.COMPARISON),
-            (data, stack) -> {
-                int enchantLevel = EnchantmentHelper.getLevel(data.get("enchantment"), stack);
-                return ((Comparison)data.get("comparison")).compare(enchantLevel, data.getInt("compare_to"));
-            }));
+        register(EnchantmentCondition.getFactory());
         register(new ConditionFactory<>(Apoli.identifier("meat"), new SerializableData(),
             (data, stack) -> stack.isFood() && stack.getItem().getFoodComponent().isMeat()));
         register(new ConditionFactory<>(Apoli.identifier("nbt"), new SerializableData()

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/item/EnchantmentCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/item/EnchantmentCondition.java
@@ -1,0 +1,37 @@
+package io.github.apace100.apoli.power.factory.condition.item;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.item.ItemStack;
+
+public class EnchantmentCondition {
+
+    public static boolean condition(SerializableData.Instance data, ItemStack stack) {
+
+        Enchantment enchantment = data.get("enchantment");
+        Comparison comparison = data.get("comparison");
+        int compareTo = data.get("compare_to");
+
+        if (enchantment != null) return comparison.compare(EnchantmentHelper.getLevel(enchantment, stack), compareTo);
+        else return comparison.compare(EnchantmentHelper.get(stack).size(), compareTo);
+
+    }
+
+    public static ConditionFactory<ItemStack> getFactory() {
+        return new ConditionFactory<>(
+            Apoli.identifier("enchantment"),
+            new SerializableData()
+                .add("enchantment", SerializableDataTypes.ENCHANTMENT, null)
+                .add("comparison", ApoliDataTypes.COMPARISON, Comparison.GREATER_THAN)
+                .add("compare_to", SerializableDataTypes.INT, 0),
+            EnchantmentCondition::condition
+        );
+    }
+
+}


### PR DESCRIPTION
This PR changes the `enchantment` item condition type so that its `enchantment` field is optional, where if it's not present, it will check how many enchantments are in the item stack being evaluated