### PR TITLE
Fix transitive dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,16 +49,20 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cca_version}"
+	modApi("dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cca_version}") {
+		exclude(group: "net.fabricmc.fabric-api")
+	}
 	include "dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cca_version}"
 
-	modImplementation "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}"
+	modApi("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}") {
+		exclude(group: "net.fabricmc.fabric-api")
+	}
 	include "dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}"
 
-	modImplementation "io.github.ladysnake:PlayerAbilityLib:${pal_version}"
+	modApi "io.github.ladysnake:PlayerAbilityLib:${pal_version}"
 	include "io.github.ladysnake:PlayerAbilityLib:${pal_version}"
 
-	modImplementation "com.github.apace100:calio:v${project.calio_version}"
+	modApi "com.github.apace100:calio:v${project.calio_version}"
 	include "com.github.apace100:calio:v${project.calio_version}"
 
 	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.clothconfig_version}") {
@@ -68,7 +72,7 @@ dependencies {
 
 	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 
-	modImplementation "com.github.DaFuqs:AdditionalEntityAttributes:${project.aea_version}"
+	modApi "com.github.DaFuqs:AdditionalEntityAttributes:${project.aea_version}"
 	include "com.github.DaFuqs:AdditionalEntityAttributes:${project.aea_version}"
 	// modImplementation "de.dafuqs:AdditionalEntityAttributes:${project.aea_version}"
 	// include "de.dafuqs:AdditionalEntityAttributes:${project.aea_version}"


### PR DESCRIPTION
PR is up again because I didn't realise that renaming a branch closed any active PRs relating to it.

Quoted from https://github.com/apace100/apoli/pull/106
> Due to a fix in Fabric Loom 1.1, this change has to be made for certain dependencies to be brought over to any dependent workspaces. [FabricMC/fabric-loom#855](https://github.com/FabricMC/fabric-loom/issues/855)