### PR TITLE
Integrate Fabric's Resource Conditions API to Apoli

### DIFF
--- a/src/main/java/io/github/apace100/apoli/Apoli.java
+++ b/src/main/java/io/github/apace100/apoli/Apoli.java
@@ -1,16 +1,12 @@
 package io.github.apace100.apoli;
 
-import com.mojang.brigadier.Command;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
 import dev.onyxstudios.cca.api.v3.entity.RespawnCopyStrategy;
 import io.github.apace100.apoli.command.PowerCommand;
-import io.github.apace100.apoli.command.PowerOperation;
-import io.github.apace100.apoli.command.PowerTypeArgumentType;
 import io.github.apace100.apoli.command.ResourceCommand;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.component.PowerHolderComponentImpl;
-import io.github.apace100.apoli.global.GlobalPowerSet;
 import io.github.apace100.apoli.global.GlobalPowerSetLoader;
 import io.github.apace100.apoli.networking.ModPacketsC2S;
 import io.github.apace100.apoli.power.PowerTypes;
@@ -24,7 +20,6 @@ import io.github.apace100.apoli.registry.ApoliClassData;
 import io.github.apace100.apoli.util.*;
 import io.github.apace100.apoli.util.modifier.ModifierOperations;
 import io.github.apace100.calio.mixin.CriteriaRegistryInvoker;
-import io.github.apace100.calio.registry.DataObjectRegistry;
 import io.github.apace100.calio.resource.OrderedResourceListenerInitializer;
 import io.github.apace100.calio.resource.OrderedResourceListenerManager;
 import io.github.ladysnake.pal.AbilitySource;
@@ -33,9 +28,8 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.command.argument.ArgumentTypes;
-import net.minecraft.command.argument.serialize.ConstantArgumentSerializer;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.registry.Registries;
 import net.minecraft.resource.ResourceType;
@@ -114,6 +108,8 @@ public class Apoli implements ModInitializer, EntityComponentInitializer, Ordere
 		BiEntityActions.register();
 
 		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(new GlobalPowerSetLoader());
+		ResourceConditions.register(ApoliResourceConditions.ANY_NAMESPACE_LOADED, jsonObject -> ApoliResourceConditions.namespacesLoaded(jsonObject, PowerTypes.LOADED_NAMESPACES, false));
+		ResourceConditions.register(ApoliResourceConditions.ALL_NAMESPACES_LOADED, jsonObject -> ApoliResourceConditions.namespacesLoaded(jsonObject, PowerTypes.LOADED_NAMESPACES, true));
 
 		CriteriaRegistryInvoker.callRegister(GainedPowerCriterion.INSTANCE);
 

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
@@ -4,11 +4,15 @@ import io.github.apace100.apoli.integration.PowerClearCallback;
 import net.minecraft.util.Identifier;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class PowerTypeRegistry {
+
     private static HashMap<Identifier, PowerType> idToPower = new HashMap<>();
+    private static Set<Identifier> disabledPowers = new HashSet<>();
 
     public static PowerType register(Identifier id, PowerType powerType) {
         if(idToPower.containsKey(id)) {
@@ -26,8 +30,17 @@ public class PowerTypeRegistry {
         return register(id, powerType);
     }
 
+    protected static void disable(Identifier id) {
+        remove(id);
+        disabledPowers.add(id);
+    }
+
     protected static void remove(Identifier id) {
         idToPower.remove(id);
+    }
+
+    public static boolean wasDisabled(Identifier id) {
+        return disabledPowers.contains(id);
     }
 
     public static int size() {
@@ -64,6 +77,7 @@ public class PowerTypeRegistry {
 
     public static void clear() {
         PowerClearCallback.EVENT.invoker().onPowerClear();
+        disabledPowers.clear();
         idToPower.clear();
     }
 

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
@@ -26,6 +26,10 @@ public class PowerTypeRegistry {
         return register(id, powerType);
     }
 
+    protected static void remove(Identifier id) {
+        idToPower.remove(id);
+    }
+
     public static int size() {
         return idToPower.size();
     }

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
@@ -18,6 +18,7 @@ public class PowerTypeRegistry {
         if(idToPower.containsKey(id)) {
             throw new IllegalArgumentException("Duplicate power type id tried to register: '" + id.toString() + "'");
         }
+        disabledPowers.remove(id);
         idToPower.put(id, powerType);
         return powerType;
     }
@@ -39,7 +40,7 @@ public class PowerTypeRegistry {
         idToPower.remove(id);
     }
 
-    public static boolean wasDisabled(Identifier id) {
+    public static boolean isDisabled(Identifier id) {
         return disabledPowers.contains(id);
     }
 

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
@@ -108,7 +108,7 @@ public class PowerTypes extends MultiJsonDataLoader implements IdentifiableResou
 
         boolean result = ApoliResourceConditions.test(id, jo);
         if (!result && PowerTypeRegistry.contains(id) && getLoadingPriority(id) < priority) {
-            PowerTypeRegistry.remove(id);
+            PowerTypeRegistry.disable(id);
         }
 
         return result;

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
@@ -5,14 +5,17 @@ import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.integration.*;
 import io.github.apace100.apoli.power.factory.PowerFactory;
 import io.github.apace100.apoli.registry.ApoliRegistries;
+import io.github.apace100.apoli.util.ApoliResourceConditions;
 import io.github.apace100.apoli.util.NamespaceAlias;
 import io.github.apace100.calio.data.MultiJsonDataLoader;
 import io.github.apace100.calio.data.SerializableData;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.Profiler;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.BiFunction;
@@ -21,6 +24,7 @@ import java.util.function.BiFunction;
 public class PowerTypes extends MultiJsonDataLoader implements IdentifiableResourceReloadListener {
 
     public static final Set<Identifier> DEPENDENCIES = new HashSet<>();
+    public static final Set<String> LOADED_NAMESPACES = new HashSet<>();
 
     private static final Identifier MULTIPLE = Apoli.identifier("multiple");
     private static final Identifier SIMPLE = Apoli.identifier("simple");
@@ -39,6 +43,8 @@ public class PowerTypes extends MultiJsonDataLoader implements IdentifiableResou
     protected void apply(Map<Identifier, List<JsonElement>> loader, ResourceManager manager, Profiler profiler) {
         PowerTypeRegistry.reset();
         LOADING_PRIORITIES.clear();
+        LOADED_NAMESPACES.clear();
+        LOADED_NAMESPACES.addAll(manager.getAllNamespaces());
         PowerReloadCallback.EVENT.invoker().onPowerReload();
         PrePowerReloadCallback.EVENT.invoker().onPrePowerReload();
         loader.forEach((id, jel) -> {
@@ -60,21 +66,26 @@ public class PowerTypes extends MultiJsonDataLoader implements IdentifiableResou
                                 || entry.getKey().equals("description")
                                 || entry.getKey().equals("hidden")
                                 || entry.getKey().equals("condition")
-                                || entry.getKey().toString().startsWith("$")
-                                || ADDITIONAL_DATA.containsKey(entry.getKey())) {
+                                || entry.getKey().startsWith("$")
+                                || ADDITIONAL_DATA.containsKey(entry.getKey())
+                                || entry.getKey().equals(ResourceConditions.CONDITIONS_KEY)) {
                                 continue;
                             }
-                            Identifier subId = new Identifier(id.toString() + "_" + entry.getKey());
+                            Identifier subId = new Identifier(id + "_" + entry.getKey());
                             try {
-                                readPower(subId, entry.getValue(), true);
-                                subPowers.add(subId);
+                                PowerType<?> subPower = readPower(subId, entry.getValue(), true);
+                                if (subPower != null) {
+                                    subPowers.add(subId);
+                                }
                             } catch (Exception e) {
                                 Apoli.LOGGER.error("There was a problem reading sub-power \"" +
-                                    subId.toString() + "\" in power file \"" + id.toString() + "\": " + e.getMessage());
+                                    subId + "\" in power file \"" + id + "\": " + e.getMessage());
                             }
                         }
-                        MultiplePowerType superPower = (MultiplePowerType) readPower(id, je, false, MultiplePowerType::new);
-                        superPower.setSubPowers(subPowers);
+                        MultiplePowerType<?> superPower = (MultiplePowerType) readPower(id, je, false, MultiplePowerType::new);
+                        if (superPower != null) {
+                            superPower.setSubPowers(subPowers);
+                        }
                         handleAdditionalData(id, factoryId, false, jo, superPower);
                         PostPowerLoadCallback.EVENT.invoker().onPostPowerLoad(id, factoryId, false, jo, superPower);
                     } else {
@@ -87,38 +98,56 @@ public class PowerTypes extends MultiJsonDataLoader implements IdentifiableResou
         });
         PostPowerReloadCallback.EVENT.invoker().onPostPowerReload();
         LOADING_PRIORITIES.clear();
+        LOADED_NAMESPACES.clear();
         SerializableData.CURRENT_NAMESPACE = null;
         SerializableData.CURRENT_PATH = null;
         Apoli.LOGGER.info("Finished loading powers from data files. Registry contains " + PowerTypeRegistry.size() + " powers.");
     }
 
-    private void readPower(Identifier id, JsonElement je, boolean isSubPower) {
-        readPower(id, je, isSubPower, PowerType::new);
+    private boolean isResourceConditionValid(Identifier id, JsonObject jo, int priority) {
+
+        boolean result = ApoliResourceConditions.test(id, jo);
+        if (!result && PowerTypeRegistry.contains(id) && getLoadingPriority(id) < priority) {
+            PowerTypeRegistry.remove(id);
+        }
+
+        return result;
+
     }
 
+    @Nullable
+    private PowerType readPower(Identifier id, JsonElement je, boolean isSubPower) {
+        return readPower(id, je, isSubPower, PowerType::new);
+    }
+
+    @Nullable
     private PowerType readPower(Identifier id, JsonElement je, boolean isSubPower,
                                 BiFunction<Identifier, PowerFactory.Instance, PowerType> powerTypeFactory) {
         JsonObject jo = je.getAsJsonObject();
-        Identifier factoryId = Identifier.tryParse(JsonHelper.getString(jo, "type"));
+        Identifier factoryId = new Identifier(JsonHelper.getString(jo, "type"));
+        int priority = JsonHelper.getInt(jo, "loading_priority", 0);
+        if (!isResourceConditionValid(id, jo, priority)) {
+            return null;
+        }
+
         if(isMultiple(factoryId)) {
             factoryId = SIMPLE;
             if(isSubPower) {
-                throw new JsonSyntaxException("Power type \"" + MULTIPLE.toString() + "\" may not be used for a sub-power of "
-                    + "another \"" + MULTIPLE.toString() + "\" power.");
+                throw new JsonSyntaxException("Power type \"" + MULTIPLE + "\" may not be used for a sub-power of "
+                    + "another \"" + MULTIPLE + "\" power.");
             }
         }
         Optional<PowerFactory> optionalFactory = ApoliRegistries.POWER_FACTORY.getOrEmpty(factoryId);
-        if(!optionalFactory.isPresent()) {
+        if(optionalFactory.isEmpty()) {
             if(NamespaceAlias.hasAlias(factoryId)) {
                 optionalFactory = ApoliRegistries.POWER_FACTORY.getOrEmpty(NamespaceAlias.resolveAlias(factoryId));
             }
-            if(!optionalFactory.isPresent()) {
-                throw new JsonSyntaxException("Power type \"" + factoryId.toString() + "\" is not defined.");
+            if(optionalFactory.isEmpty()) {
+                throw new JsonSyntaxException("Power type \"" + factoryId + "\" is not defined.");
             }
         }
         PowerFactory.Instance factoryInstance = optionalFactory.get().read(jo);
         PowerType type = powerTypeFactory.apply(id, factoryInstance);
-        int priority = JsonHelper.getInt(jo, "loading_priority", 0);
         String name = JsonHelper.getString(jo, "name", "");
         String description = JsonHelper.getString(jo, "description", "");
         boolean hidden = JsonHelper.getBoolean(jo, "hidden", false);

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
@@ -127,6 +127,7 @@ public class PowerTypes extends MultiJsonDataLoader implements IdentifiableResou
         Identifier factoryId = new Identifier(JsonHelper.getString(jo, "type"));
         int priority = JsonHelper.getInt(jo, "loading_priority", 0);
         if (!isResourceConditionValid(id, jo, priority)) {
+            LOADING_PRIORITIES.put(id, priority);
             return null;
         }
 

--- a/src/main/java/io/github/apace100/apoli/util/ApoliResourceConditions.java
+++ b/src/main/java/io/github/apace100/apoli/util/ApoliResourceConditions.java
@@ -1,0 +1,53 @@
+package io.github.apace100.apoli.util;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import io.github.apace100.apoli.Apoli;
+import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+import java.util.Set;
+
+public class ApoliResourceConditions {
+
+	public static final Identifier ANY_NAMESPACE_LOADED = Apoli.identifier("any_namespace_loaded");
+
+	public static final Identifier ALL_NAMESPACES_LOADED = Apoli.identifier("all_namespaces_loaded");
+
+	public static boolean namespacesLoaded(JsonObject jsonObject, Set<String> namespaces, boolean and) {
+
+		JsonArray jsonArray = JsonHelper.getArray(jsonObject, "namespaces");
+		for (JsonElement jsonElement : jsonArray) {
+			if (jsonElement.isJsonPrimitive()) {
+				if (namespaces.contains(jsonElement.getAsString()) != and) {
+					return !and;
+				}
+			} else {
+				throw new JsonParseException("Invalid " + jsonElement + " entry: expected a JSON string!");
+			}
+		}
+
+		return and;
+
+	}
+
+	public static boolean test(Identifier id, JsonObject jsonObject) {
+
+		try {
+			JsonArray conditions = JsonHelper.getArray(jsonObject, ResourceConditions.CONDITIONS_KEY, null);
+			if (conditions == null) {
+				return true;
+			} else {
+				return ResourceConditions.conditionsMatch(conditions, true);
+			}
+		} catch (RuntimeException e) {
+			Apoli.LOGGER.error("There was a problem parsing the resource condition(s) of power file " + id + " (skipping): " + e.getMessage());
+			return false;
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR integrates Fabric's Resource Conditions API to Apoli's power loader system. It also adds two new resource conditions: `apoli:any_namespace_loaded` and `apoli:all_namespaces_loaded` which can be used to check if any or all of the namespaces listed are loaded respectively. It only works when loading powers

Here's an example power that will only be registered if the `eggolib` namespace is loaded:
```json
{
    "type": "apoli:action_on_callback",
    "entity_action_gained": {
        "type": "apoli:execute_command",
        "command": "say Hello world!"
    },
    "fabric:load_conditions": [
        {
            "condition": "apoli:any_namespace_loaded",
            "namespaces": [
                "eggolib"
            ]
        }
    ]
}
```