### PR TITLE
Make the `owner` bi-entity condition work for other ownable entities

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/BiEntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/BiEntityConditions.java
@@ -2,6 +2,7 @@ package io.github.apace100.apoli.power.factory.condition;
 
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.bientity.OwnerCondition;
 import io.github.apace100.apoli.power.factory.condition.bientity.RelativeRotationCondition;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.apoli.util.Comparison;
@@ -10,13 +11,12 @@ import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.Tameable;
 import net.minecraft.entity.mob.Angerable;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.registry.Registry;
 import net.minecraft.util.Pair;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.registry.Registry;
 import net.minecraft.world.RaycastContext;
 
 import java.util.List;
@@ -111,14 +111,7 @@ public class BiEntityConditions {
                 }
             }
         ));
-        register(new ConditionFactory<>(Apoli.identifier("owner"), new SerializableData(),
-            (data, pair) -> {
-                if(pair.getRight() instanceof Tameable) {
-                    return pair.getLeft() == ((Tameable)pair.getRight()).getOwner();
-                }
-                return false;
-            }
-        ));
+        register(OwnerCondition.getFactory());
         register(new ConditionFactory<>(Apoli.identifier("riding"), new SerializableData(),
             (data, pair) -> pair.getLeft().getVehicle() == pair.getRight()
         ));

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/bientity/OwnerCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/bientity/OwnerCondition.java
@@ -1,0 +1,31 @@
+package io.github.apace100.apoli.power.factory.condition.bientity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.Ownable;
+import net.minecraft.entity.Tameable;
+import net.minecraft.util.Pair;
+
+public class OwnerCondition {
+
+	public static boolean condition(SerializableData.Instance data, Pair<Entity, Entity> actorAndTarget) {
+
+		Entity actor = actorAndTarget.getLeft();
+		Entity target = actorAndTarget.getRight();
+
+		return (target instanceof Tameable tamable && actor == tamable.getOwner())
+			|| (target instanceof Ownable ownable && actor == ownable.getOwner());
+
+	}
+
+	public static ConditionFactory<Pair<Entity, Entity>> getFactory() {
+		return new ConditionFactory<>(
+			Apoli.identifier("owner"),
+			new SerializableData(),
+			OwnerCondition::condition
+		);
+	}
+
+}


### PR DESCRIPTION
This PR changes the `owner` bi-entity condition type so that it works for other ownable entities too, such as projectiles, fishing bobbers, etc.