### PR TITLE
Add `fuel` item condition type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/ItemConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/ItemConditions.java
@@ -3,23 +3,21 @@ package io.github.apace100.apoli.power.factory.condition;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.factory.condition.item.EnchantmentCondition;
+import io.github.apace100.apoli.power.factory.condition.item.FuelCondition;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.apoli.util.StackPowerUtil;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolItem;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtHelper;
 import net.minecraft.recipe.Ingredient;
-import net.minecraft.util.Identifier;
 import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
 
 import java.util.List;
 
@@ -128,6 +126,7 @@ public class ItemConditions {
         register(new ConditionFactory<>(Apoli.identifier("is_equippable"), new SerializableData()
             .add("equipment_slot", SerializableDataTypes.EQUIPMENT_SLOT),
             (data, stack) -> MobEntity.getPreferredEquipmentSlot(stack) == data.get("equipment_slot")));
+        register(FuelCondition.getFactory());
     }
 
     private static void register(ConditionFactory<ItemStack> conditionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/item/FuelCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/item/FuelCondition.java
@@ -1,0 +1,35 @@
+package io.github.apace100.apoli.power.factory.condition.item;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.fabricmc.fabric.api.registry.FuelRegistry;
+import net.minecraft.item.ItemStack;
+
+public class FuelCondition {
+
+	public static boolean condition(SerializableData.Instance data, ItemStack stack) {
+
+		Integer fuelTime = FuelRegistry.INSTANCE.get(stack.getItem());
+		Comparison comparison = data.get("comparison");
+		Integer compareTo = data.get("compare_to");
+
+		return fuelTime != null
+			&& comparison.compare(fuelTime, compareTo);
+
+	}
+
+	public static ConditionFactory<ItemStack> getFactory() {
+		return new ConditionFactory<>(
+			Apoli.identifier("fuel"),
+			new SerializableData()
+				.add("comparison", ApoliDataTypes.COMPARISON, Comparison.GREATER_THAN)
+				.add("compare_to", SerializableDataTypes.INT, 0),
+			FuelCondition::condition
+		);
+	}
+
+}


### PR DESCRIPTION
This PR adds a `fuel` item condition type, which checks if the item has a burn time value and compares that value to a specific value. By default, it has a `comparison` value of `">"` and a `compare_to` value of `0`