### PR TITLE
Add `modify_bounciness` power type.

### DIFF
--- a/src/main/java/io/github/apace100/apoli/Apoli.java
+++ b/src/main/java/io/github/apace100/apoli/Apoli.java
@@ -97,6 +97,7 @@ public class Apoli implements ModInitializer, EntityComponentInitializer, Ordere
 		Registry.register(Registries.LOOT_CONDITION_TYPE, Apoli.identifier("power"), PowerLootCondition.TYPE);
 
 		ApoliClassData.registerAll();
+		BouncinessMultiplierRegistry.registerAll();
 
 		ModifierOperations.registerAll();
 

--- a/src/main/java/io/github/apace100/apoli/mixin/BlockMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/BlockMixin.java
@@ -1,0 +1,62 @@
+package io.github.apace100.apoli.mixin;
+
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import io.github.apace100.apoli.power.ModifyBouncinessPower;
+import io.github.apace100.apoli.util.BouncinessMultiplierRegistry;
+import io.github.apace100.calio.ClassUtil;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.pattern.CachedBlockPosition;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Block.class)
+public class BlockMixin {
+
+    @Unique private World apoli$landedUponWorld;
+    @Unique private BlockPos apoli$landedUponBlockPos;
+    @Unique private Entity apoli$landedUponEntity;
+
+    @Inject(method = "onLandedUpon", at = @At(value = "HEAD"))
+    private void captureFallDamageCancelParams(World world, BlockState state, BlockPos pos, Entity entity, float fallDistance, CallbackInfo ci) {
+        this.apoli$landedUponWorld = world;
+        this.apoli$landedUponBlockPos = pos;
+        this.apoli$landedUponEntity = entity;
+    }
+
+    @ModifyArg(method = "onLandedUpon", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;handleFallDamage(FFLnet/minecraft/entity/damage/DamageSource;)Z"), index = 1)
+    private float cancelFallDamage(float multiplier) {
+        if (ModifyBouncinessPower.shouldCancelFallDamage(apoli$landedUponEntity, new CachedBlockPosition(apoli$landedUponWorld, apoli$landedUponBlockPos, false))) {
+            return 0.0F;
+        }
+        return multiplier;
+    }
+
+    @Unique private Entity apoli$onLandEntity;
+
+    @Inject(method = "onEntityLand", at = @At(value = "HEAD"))
+    private void captureBouncinessParams(BlockView world, Entity entity, CallbackInfo ci) {
+        apoli$onLandEntity = entity;
+    }
+
+
+    @ModifyArg(method = "onEntityLand", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;setVelocity(Lnet/minecraft/util/math/Vec3d;)V"))
+    private Vec3d modifyBouncinessY(Vec3d original) {
+        CachedBlockPosition cbp = new CachedBlockPosition(apoli$onLandEntity.getWorld(), apoli$onLandEntity.getSteppingPos(), false);
+        if (apoli$onLandEntity.getVelocity().getY() < 0.0 && PowerHolderComponent.getPowers(apoli$onLandEntity, ModifyBouncinessPower.class).stream().anyMatch(p -> p.doesApply(cbp))) {
+            return new Vec3d(original.getX(), MathHelper.abs(ModifyBouncinessPower.modify(apoli$onLandEntity, BouncinessMultiplierRegistry.getValue(ClassUtil.castClass(this.getClass())), cbp)), original.getZ());
+        }
+        return original;
+    }
+}

--- a/src/main/java/io/github/apace100/apoli/mixin/EntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/EntityMixin.java
@@ -67,6 +67,13 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
 
     @Shadow protected Object2DoubleMap<TagKey<Fluid>> fluidHeight;
 
+    @Inject(method = "bypassesLandingEffects", at = @At("RETURN"), cancellable = true)
+    private void overrideDefaultLandingBehavior(CallbackInfoReturnable<Boolean> cir) {
+        if (PowerHolderComponent.hasPower((Entity)(Object)this, ModifyBouncinessPower.class)) {
+            cir.setReturnValue(true);
+        }
+    }
+
     @Inject(method = "isTouchingWater", at = @At("HEAD"), cancellable = true)
     private void makeEntitiesIgnoreWater(CallbackInfoReturnable<Boolean> cir) {
         if(PowerHolderComponent.hasPower((Entity)(Object)this, IgnoreWaterPower.class)) {

--- a/src/main/java/io/github/apace100/apoli/power/ModifyBouncinessPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyBouncinessPower.java
@@ -1,0 +1,72 @@
+package io.github.apace100.apoli.power;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.util.ResourceOperation;
+import io.github.apace100.apoli.util.modifier.Modifier;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataType;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.pattern.CachedBlockPosition;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class ModifyBouncinessPower extends ValueModifyingPower {
+
+    private final Predicate<CachedBlockPosition> blockCondition;
+    private final boolean takeFallDamage;
+    private final Stage stage;
+
+    public ModifyBouncinessPower(PowerType<?> type, LivingEntity entity, Predicate<CachedBlockPosition> blockCondition, boolean takeFallDamage, Stage stage) {
+        super(type, entity);
+        this.blockCondition = blockCondition;
+        this.takeFallDamage = takeFallDamage;
+        this.stage = stage;
+    }
+
+    public static float modify(Entity entity, double baseBounciness, CachedBlockPosition cbp) {
+        double preY = PowerHolderComponent.modify(entity, ModifyBouncinessPower.class, (float)baseBounciness, p -> p.doesApply(cbp) && p.stage == Stage.PRE);
+        return PowerHolderComponent.modify(entity, ModifyBouncinessPower.class, (float)(entity.getVelocity().getY() * preY), p -> p.doesApply(cbp) && p.stage == Stage.POST);
+    }
+
+    public boolean doesApply(CachedBlockPosition cbp) {
+        return blockCondition == null || blockCondition.test(cbp);
+    }
+
+    public static boolean shouldCancelFallDamage(Entity entity, CachedBlockPosition cbp) {
+        return PowerHolderComponent.getPowers(entity, ModifyBouncinessPower.class).stream().anyMatch(p -> p.doesApply(cbp) && !p.takeFallDamage);
+    }
+
+    public static PowerFactory createFactory() {
+        return new PowerFactory<>(Apoli.identifier("modify_bounciness"),
+            new SerializableData()
+                .add("modifier", Modifier.DATA_TYPE, null)
+                .add("modifiers", Modifier.LIST_TYPE, null)
+                .add("block_condition", ApoliDataTypes.BLOCK_CONDITION, null)
+                .add("take_fall_damage", SerializableDataTypes.BOOLEAN, false)
+                .add("stage", SerializableDataType.enumValue(Stage.class), Stage.PRE),
+            data ->
+                (type, player) -> {
+                    ModifyBouncinessPower power = new ModifyBouncinessPower(type, player, data.get("block_condition"), data.getBoolean("take_fall_damage"), data.get("stage"));
+                    data.ifPresent("modifier", power::addModifier);
+                    data.<List<Modifier>>ifPresent("modifiers",
+                        mods -> mods.forEach(power::addModifier)
+                    );
+                    return power;
+                })
+            .allowCondition();
+    }
+
+    public enum Stage {
+        PRE,
+        POST
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -123,6 +123,7 @@ public class PowerFactories {
         register(ReplaceLootTablePower::createFactory);
         register(ModifyVelocityPower::createFactory);
         register(() -> Power.createSimpleFactory(GroundedPower::new, Apoli.identifier("grounded")));
+        register(ModifyBouncinessPower::createFactory);
     }
 
     private static void register(PowerFactory<?> powerFactory) {

--- a/src/main/java/io/github/apace100/apoli/util/BouncinessMultiplierRegistry.java
+++ b/src/main/java/io/github/apace100/apoli/util/BouncinessMultiplierRegistry.java
@@ -1,0 +1,29 @@
+package io.github.apace100.apoli.util;
+
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.BedBlock;
+import net.minecraft.block.SlimeBlock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BouncinessMultiplierRegistry {
+
+    private static final Map<Class<? extends AbstractBlock>, Double> BOUNCINESS_MULTIPLIERS = new HashMap<>();
+
+    public static void registerAll() {
+        BOUNCINESS_MULTIPLIERS.put(BedBlock.class, 0.66);
+        BOUNCINESS_MULTIPLIERS.put(SlimeBlock.class, 1.0);
+    }
+
+    public static <T extends AbstractBlock> double getValue(Class<T> key) {
+        if (BOUNCINESS_MULTIPLIERS.containsKey(key)) {
+            return BOUNCINESS_MULTIPLIERS.get(key);
+        }
+        return 0.0F;
+    }
+
+    public static <T extends AbstractBlock> void register(Class<T> blockClass, double value) {
+        BOUNCINESS_MULTIPLIERS.put(blockClass, value);
+    }
+}

--- a/src/main/resources/apoli.mixins.json
+++ b/src/main/resources/apoli.mixins.json
@@ -10,6 +10,7 @@
     "BiomeBuilderMixin",
     "BiomeMixin",
     "BlockItemMixin",
+    "BlockMixin",
     "CraftingInventoryAccessor",
     "CraftingInventoryMixin",
     "CraftingResultSlotMixin",

--- a/src/test/resources/data/apoli/powers/modify_bounciness.json
+++ b/src/test/resources/data/apoli/powers/modify_bounciness.json
@@ -1,0 +1,7 @@
+{
+  "type": "apoli:modify_bounciness",
+  "modifier": {
+    "operation": "addition",
+    "value": 1.0
+  }
+}


### PR DESCRIPTION
This PR adds the `apoli:modify_bounciness` power type. This changes the multiplier at which the player's existing velocity is applied upon landing on something.

## Fields
- `modifier`/`modifiers` (Optional) | These fields should be self explanatory.
- `block_condition` (Optional) | the block condition to test against the landing block to determine whether the player should bounce on a block.
- `take_fall_damage` Boolean (Optional) | Whether the player should take fall damage upon bouncing, defaults to false.
- `stage` (Optional) | Either `"pre"` or `"post"`. Determines at which stage of the calculation the modifier(s) should apply.
  - Pre is before the entity's velocity has been applied to the block's bounciness value.
  - Post is after the entity's velocity has been applied to the pre value.

## Additional Info
This power may be a nightmare for compatibility with bouncy modded blocks, this is because there is no shared bounciness field in the base block class, they instead opted for hardcoded bounciness. I have tried circumventing this by adding a `BouncinessMultiplierRegistry`, which stores multipliers for bounciness for specific classes to use when this power is active.