### PR TITLE
Add `velocity` entity condition type.

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
@@ -7,10 +7,7 @@ import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.mixin.EntityAccessor;
 import io.github.apace100.apoli.power.*;
-import io.github.apace100.apoli.power.factory.condition.entity.BlockCollisionCondition;
-import io.github.apace100.apoli.power.factory.condition.entity.ElytraFlightPossibleCondition;
-import io.github.apace100.apoli.power.factory.condition.entity.RaycastCondition;
-import io.github.apace100.apoli.power.factory.condition.entity.ScoreboardCondition;
+import io.github.apace100.apoli.power.factory.condition.entity.*;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.apoli.util.Shape;
@@ -547,6 +544,7 @@ public class EntityConditions {
             }));
         register(RaycastCondition.getFactory());
         register(ElytraFlightPossibleCondition.getFactory());
+        register(VelocityCondition.getFactory());
     }
 
     private static void register(ConditionFactory<Entity> conditionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/VelocityCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/VelocityCondition.java
@@ -41,7 +41,7 @@ public class VelocityCondition {
         return new ConditionFactory<>(
             Apoli.identifier("velocity"),
             new SerializableData()
-                .add("axes", SerializableDataTypes.AXIS_SET)
+                .add("axes", SerializableDataTypes.AXIS_SET, EnumSet.allOf(Direction.Axis.class))
                 .add("compare_to", SerializableDataTypes.DOUBLE)
                 .add("comparison", ApoliDataTypes.COMPARISON, Comparison.GREATER_THAN_OR_EQUAL),
             VelocityCondition::condition

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/VelocityCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/VelocityCondition.java
@@ -1,0 +1,51 @@
+package io.github.apace100.apoli.power.factory.condition.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.block.pattern.CachedBlockPosition;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.EnumSet;
+import java.util.function.Predicate;
+
+public class VelocityCondition {
+
+    public static boolean condition(SerializableData.Instance data, Entity entity) {
+
+        Comparison comparison = data.get("comparison");
+        EnumSet<Direction.Axis> axes = data.get("axes");
+        Vec3d velocity = entity.getVelocity();
+        double compareTo = data.getDouble("compare_to");
+        for(Direction.Axis axis : axes) {
+            if(!switch(axis) {
+                case X -> comparison.compare(velocity.x, compareTo);
+                case Y -> comparison.compare(velocity.y, compareTo);
+                case Z -> comparison.compare(velocity.z, compareTo);
+            }) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static ConditionFactory<Entity> getFactory() {
+        return new ConditionFactory<>(
+            Apoli.identifier("velocity"),
+            new SerializableData()
+                .add("axes", SerializableDataTypes.AXIS_SET)
+                .add("compare_to", SerializableDataTypes.DOUBLE)
+                .add("comparison", ApoliDataTypes.COMPARISON, Comparison.GREATER_THAN_OR_EQUAL),
+            VelocityCondition::condition
+        );
+    }
+
+}

--- a/src/test/resources/data/apoli/powers/moon_jump.json
+++ b/src/test/resources/data/apoli/powers/moon_jump.json
@@ -1,0 +1,53 @@
+{
+  "type": "apoli:multiple",
+  "falling": {
+    "type": "apoli:modify_velocity",
+    "modifier": {
+      "value": -0.75,
+      "operation": "multiply_total"
+    },
+    "axes": [
+      "y"
+    ],
+    "condition": {
+      "type": "apoli:velocity",
+      "axes": [
+        "y"
+      ],
+      "compare_to": 0,
+      "comparison": "<"
+    }
+  },
+  "upwards": {
+    "type": "apoli:modify_velocity",
+    "modifier": {
+      "value": -0.5,
+      "operation": "multiply_total"
+    },
+    "axes": [
+      "y"
+    ],
+    "condition": {
+      "type": "apoli:velocity",
+      "axes": [
+        "y"
+      ],
+      "compare_to": 0,
+      "comparison": ">"
+    }
+  },
+  "jump_height": {
+    "type": "apoli:modify_jump",
+    "modifier": {
+      "operation": "addition",
+      "value": 1.0
+    }
+  },
+  "fall_damage_immunity": {
+    "type": "apoli:invulnerability",
+    "damage_condition": {
+      "type": "apoli:name",
+      "name": "fall"
+    }
+  }
+}


### PR DESCRIPTION
Adds a new entity condition type that can compare the entity's velocity to a value.

### Fields
| Field  | Type | Default | Description
-------|------|---------|-------------
`axes` | [Array](https://origins.readthedocs.io/en/latest/types/data_types/array/) of [Strings](https://origins.readthedocs.io/en/latest/types/data_types/string/)| `["x","y","z"]` | The axes that should be used for the comparison. Accepts `"x"`, `"y"`, and/or `"z"`.
`comparison` | [Comparison](https://origins.readthedocs.io/en/latest/types/data_types/comparison/) | `">="` | How the `axes`' velocity should be compared to the specified value.
`compare_to` | [Float](https://origins.readthedocs.io/en/latest/types/data_types/float/) |  | The value for the axes specified in `axes` to compare to.

