### PR TITLE
Allows for multiple overlay powers to work at the same time

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
@@ -94,7 +94,7 @@ public abstract class GameRendererMixin {
     private void renderOverlayPowers(float tickDelta, long startTime, boolean tick, CallbackInfo ci) {
         boolean hudHidden = this.client.options.hudHidden;
         boolean thirdPerson = !client.options.getPerspective().isFirstPerson();
-        PowerHolderComponent.withPower(client.getCameraEntity(), OverlayPower.class, p -> {
+        PowerHolderComponent.withPowers(client.getCameraEntity(), OverlayPower.class, p -> {
             if(p.getDrawPhase() != OverlayPower.DrawPhase.ABOVE_HUD) {
                 return false;
             }

--- a/src/main/java/io/github/apace100/apoli/mixin/InGameHudMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/InGameHudMixin.java
@@ -30,7 +30,7 @@ public class InGameHudMixin {
     private void renderOnHud(DrawContext context, float tickDelta, CallbackInfo ci) {
         boolean hudHidden = client.options.hudHidden;
         boolean thirdPerson = !client.options.getPerspective().isFirstPerson();
-        PowerHolderComponent.withPower(client.getCameraEntity(), OverlayPower.class, p -> {
+        PowerHolderComponent.withPowers(client.getCameraEntity(), OverlayPower.class, p -> {
             if(p.getDrawPhase() != OverlayPower.DrawPhase.BELOW_HUD) {
                 return false;
             }

--- a/src/main/java/io/github/apace100/apoli/mixin/InGameHudMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/InGameHudMixin.java
@@ -18,7 +18,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 @Mixin(InGameHud.class)
 @Environment(EnvType.CLIENT)
@@ -30,18 +33,21 @@ public class InGameHudMixin {
     private void renderOnHud(DrawContext context, float tickDelta, CallbackInfo ci) {
         boolean hudHidden = client.options.hudHidden;
         boolean thirdPerson = !client.options.getPerspective().isFirstPerson();
-        PowerHolderComponent.withPowers(client.getCameraEntity(), OverlayPower.class, p -> {
-            if(p.getDrawPhase() != OverlayPower.DrawPhase.BELOW_HUD) {
+        List<OverlayPower> overlays = PowerHolderComponent.getPowers(client.getCameraEntity(), OverlayPower.class);
+        overlays.sort(Comparator.comparing(OverlayPower::getPriority));
+        Predicate<OverlayPower> overlayPredicate = overlay -> {
+            if(overlay.getDrawPhase() != OverlayPower.DrawPhase.BELOW_HUD) {
                 return false;
             }
-            if(hudHidden && p.doesHideWithHud()) {
+            if(hudHidden && overlay.doesHideWithHud()) {
                 return false;
             }
-            if(thirdPerson && !p.shouldBeVisibleInThirdPerson()) {
+            if(thirdPerson && !overlay.shouldBeVisibleInThirdPerson()) {
                 return false;
             }
             return true;
-        }, OverlayPower::render);
+        };
+        overlays.stream().filter(overlayPredicate).forEach(OverlayPower::render);
 
         for(GameHudRender hudRender : GameHudRender.HUD_RENDERS) {
             hudRender.render(context, tickDelta);

--- a/src/main/java/io/github/apace100/apoli/power/OverlayPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/OverlayPower.java
@@ -9,6 +9,7 @@ import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.block.NetherPortalBlock;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.*;
 import net.minecraft.entity.LivingEntity;
@@ -18,6 +19,7 @@ import net.minecraft.util.math.MathHelper;
 public class OverlayPower extends Power {
 
     private final Identifier texture;
+    private final Integer priority;
     private final float strength;
     private final float red;
     private final float green;
@@ -35,9 +37,10 @@ public class OverlayPower extends Power {
         BELOW_HUD, ABOVE_HUD
     }
 
-    public OverlayPower(PowerType<?> type, LivingEntity entity, Identifier texture, float strength, float red, float green, float blue, DrawMode drawMode, DrawPhase drawPhase, boolean hideWithHud, boolean visibleInThirdPerson) {
+    public OverlayPower(PowerType<?> type, LivingEntity entity, Identifier texture, int priority, float strength, float red, float green, float blue, DrawMode drawMode, DrawPhase drawPhase, boolean hideWithHud, boolean visibleInThirdPerson) {
         super(type, entity);
         this.texture = texture;
+        this.priority = priority;
         this.strength = strength;
         this.red = red;
         this.green = green;
@@ -46,6 +49,10 @@ public class OverlayPower extends Power {
         this.drawPhase = drawPhase;
         this.hideWithHud = hideWithHud;
         this.visibleInThirdPerson = visibleInThirdPerson;
+    }
+
+    public Integer getPriority() {
+        return priority;
     }
 
     public DrawPhase getDrawPhase() {
@@ -126,6 +133,7 @@ public class OverlayPower extends Power {
         return new PowerFactory<>(Apoli.identifier("overlay"),
             new SerializableData()
                 .add("texture", SerializableDataTypes.IDENTIFIER)
+                .add("priority", SerializableDataTypes.INT, 1)
                 .add("strength", SerializableDataTypes.FLOAT, 1.0F)
                 .add("red", SerializableDataTypes.FLOAT, 1.0F)
                 .add("green", SerializableDataTypes.FLOAT, 1.0F)
@@ -137,6 +145,7 @@ public class OverlayPower extends Power {
             data ->
                 (type, player) -> new OverlayPower(type, player,
                     data.getId("texture"),
+                    data.getInt("priority"),
                     data.getFloat("strength"),
                     data.getFloat("red"),
                     data.getFloat("green"),


### PR DESCRIPTION
changes the `PowerHolderComponent#withPower` methods in `InGameHudMixin` and `GameRendererMixin` to use `PowerHolderComponent#withPowers`, allowing for multiple overlays to be displayed at once