### PR TITLE
Add new fields to the `*_advancement` entity action types

### DIFF
--- a/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
+++ b/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
@@ -30,6 +30,7 @@ import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.command.AdvancementCommand;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
 import net.minecraft.util.math.BlockPos;
@@ -252,6 +253,10 @@ public class ApoliDataTypes {
             LegacyMaterial.class, SerializableDataTypes.STRING,
             LegacyMaterial::getMaterial, LegacyMaterial::new
     );
+
+    public static final SerializableDataType<AdvancementCommand.Operation> ADVANCEMENT_OPERATION = SerializableDataType.enumValue(AdvancementCommand.Operation.class);
+
+    public static final SerializableDataType<AdvancementCommand.Selection> ADVANCEMENT_SELECTION = SerializableDataType.enumValue(AdvancementCommand.Selection.class);
 
     public static final SerializableDataType<List<LegacyMaterial>> LEGACY_MATERIALS = SerializableDataType.list(LEGACY_MATERIAL);
 

--- a/src/main/java/io/github/apace100/apoli/mixin/AdvancementCommandAccessor.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/AdvancementCommandAccessor.java
@@ -1,0 +1,18 @@
+package io.github.apace100.apoli.mixin;
+
+import net.minecraft.advancement.Advancement;
+import net.minecraft.server.command.AdvancementCommand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.List;
+
+@Mixin(AdvancementCommand.class)
+public interface AdvancementCommandAccessor {
+
+    @Invoker
+    static List<Advancement> callSelect(Advancement advancement, AdvancementCommand.Selection selection) {
+        throw new AssertionError();
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/GrantAdvancementAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/GrantAdvancementAction.java
@@ -1,41 +1,71 @@
 package io.github.apace100.apoli.power.factory.action.entity;
 
 import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.mixin.AdvancementCommandAccessor;
 import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.apoli.util.AdvancementUtil;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.advancement.Advancement;
-import net.minecraft.advancement.AdvancementProgress;
 import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerAdvancementLoader;
+import net.minecraft.server.command.AdvancementCommand;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class GrantAdvancementAction {
 
     public static void action(SerializableData.Instance data, Entity entity) {
-        if (entity instanceof ServerPlayerEntity player) {
-            Identifier id = data.getId("advancement");
-            if (player.getServer() != null) {
-                Advancement adv = player.getServer().getAdvancementLoader().get(id);
-                grant(player, adv);
-            }
+
+        MinecraftServer server = entity.getServer();
+        if (server == null || !(entity instanceof ServerPlayerEntity serverPlayerEntity)) {
+            return;
         }
+
+        ServerAdvancementLoader advancementLoader = server.getAdvancementLoader();
+        AdvancementCommand.Selection selection = data.get("selection");
+
+        if (selection == AdvancementCommand.Selection.EVERYTHING) {
+            AdvancementUtil.processAdvancements(advancementLoader.getAdvancements(), AdvancementCommand.Operation.GRANT, serverPlayerEntity);
+        } else if (data.isPresent("advancement")) {
+
+            Identifier advancementId = data.get("advancement");
+            Advancement advancement = advancementLoader.get(advancementId);
+            if (advancement == null) {
+                Apoli.LOGGER.warn("Unknown advancement (\"" + advancementId + "\") referenced in `grant_advancement` entity action type!");
+                return;
+            }
+
+            Set<String> criteria = new HashSet<>();
+
+            data.ifPresent("criterion", criteria::add);
+            data.ifPresent("criteria", criteria::addAll);
+
+            if (criteria.isEmpty()) {
+                AdvancementUtil.processAdvancements(AdvancementCommandAccessor.callSelect(advancement, selection), AdvancementCommand.Operation.GRANT, serverPlayerEntity);
+            } else {
+                AdvancementUtil.processCriteria(advancement, criteria, AdvancementCommand.Operation.GRANT, serverPlayerEntity);
+            }
+
+        }
+
     }
 
     public static ActionFactory<Entity> getFactory() {
-        return new ActionFactory<>(Apoli.identifier("grant_advancement"),
-                new SerializableData()
-                        .add("advancement", SerializableDataTypes.IDENTIFIER),
-                GrantAdvancementAction::action
+        return new ActionFactory<>(
+            Apoli.identifier("grant_advancement"),
+            new SerializableData()
+                .add("advancement", SerializableDataTypes.IDENTIFIER, null)
+                .add("criterion", SerializableDataTypes.STRING, null)
+                .add("criteria", SerializableDataTypes.STRINGS, null)
+                .add("selection", ApoliDataTypes.ADVANCEMENT_SELECTION, AdvancementCommand.Selection.ONLY),
+            GrantAdvancementAction::action
         );
     }
 
-    private static void grant(ServerPlayerEntity player, Advancement advancement) {
-        AdvancementProgress advancementProgress = player.getAdvancementTracker().getProgress(advancement);
-        if (!advancementProgress.isDone()) {
-            for (String criterion : advancementProgress.getUnobtainedCriteria()) {
-                player.getAdvancementTracker().grantCriterion(advancement, criterion);
-            }
-        }
-    }
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/RevokeAdvancementAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/RevokeAdvancementAction.java
@@ -1,41 +1,71 @@
 package io.github.apace100.apoli.power.factory.action.entity;
 
 import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.mixin.AdvancementCommandAccessor;
 import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.apoli.util.AdvancementUtil;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.advancement.Advancement;
-import net.minecraft.advancement.AdvancementProgress;
 import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerAdvancementLoader;
+import net.minecraft.server.command.AdvancementCommand;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class RevokeAdvancementAction {
 
     public static void action(SerializableData.Instance data, Entity entity) {
-        if (entity instanceof ServerPlayerEntity player) {
-            Identifier id = data.getId("advancement");
-            if (player.getServer() != null) {
-                Advancement adv = player.getServer().getAdvancementLoader().get(id);
-                revoke(player, adv);
-            }
+
+        MinecraftServer server = entity.getServer();
+        if (server == null || !(entity instanceof ServerPlayerEntity serverPlayerEntity)) {
+            return;
         }
+
+        ServerAdvancementLoader advancementLoader = server.getAdvancementLoader();
+        AdvancementCommand.Selection selection = data.get("selection");
+
+        if (selection == AdvancementCommand.Selection.EVERYTHING) {
+            AdvancementUtil.processAdvancements(advancementLoader.getAdvancements(), AdvancementCommand.Operation.REVOKE, serverPlayerEntity);
+        } else if (data.isPresent("advancement")) {
+
+            Identifier advancementId = data.get("advancement");
+            Advancement advancement = advancementLoader.get(advancementId);
+            if (advancement == null) {
+                Apoli.LOGGER.warn("Unknown advancement (\"" + advancementId + "\") referenced in `revoke_advancement` entity action type!");
+                return;
+            }
+
+            Set<String> criteria = new HashSet<>();
+
+            data.ifPresent("criterion", criteria::add);
+            data.ifPresent("criteria", criteria::addAll);
+
+            if (criteria.isEmpty()) {
+                AdvancementUtil.processAdvancements(AdvancementCommandAccessor.callSelect(advancement, selection), AdvancementCommand.Operation.REVOKE, serverPlayerEntity);
+            } else {
+                AdvancementUtil.processCriteria(advancement, criteria, AdvancementCommand.Operation.REVOKE, serverPlayerEntity);
+            }
+
+        }
+
     }
 
     public static ActionFactory<Entity> getFactory() {
-        return new ActionFactory<>(Apoli.identifier("revoke_advancement"),
-                new SerializableData()
-                        .add("advancement", SerializableDataTypes.IDENTIFIER),
-                RevokeAdvancementAction::action
+        return new ActionFactory<>(
+            Apoli.identifier("revoke_advancement"),
+            new SerializableData()
+                .add("advancement", SerializableDataTypes.IDENTIFIER, null)
+                .add("criterion", SerializableDataTypes.STRING, null)
+                .add("criteria", SerializableDataTypes.STRINGS, null)
+                .add("selection", ApoliDataTypes.ADVANCEMENT_SELECTION, AdvancementCommand.Selection.ONLY),
+            RevokeAdvancementAction::action
         );
     }
 
-    private static void revoke(ServerPlayerEntity player, Advancement advancement) {
-        AdvancementProgress advancementProgress = player.getAdvancementTracker().getProgress(advancement);
-        if (advancementProgress.isAnyObtained()) {
-            for (String string : advancementProgress.getObtainedCriteria()) {
-                player.getAdvancementTracker().revokeCriterion(advancement, string);
-            }
-        }
-    }
 }

--- a/src/main/java/io/github/apace100/apoli/util/AdvancementUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/AdvancementUtil.java
@@ -1,0 +1,24 @@
+package io.github.apace100.apoli.util;
+
+import net.minecraft.advancement.Advancement;
+import net.minecraft.server.command.AdvancementCommand;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class AdvancementUtil {
+
+    public static void processCriteria(Advancement advancement, Set<String> criteria, AdvancementCommand.Operation operation, ServerPlayerEntity serverPlayerEntity) {
+        for (String criterion : criteria.stream().filter(c -> advancement.getCriteria().containsKey(c)).toList()) {
+            operation.processEachCriterion(serverPlayerEntity, advancement, criterion);
+        }
+    }
+
+    public static void processAdvancements(Collection<Advancement> advancements, AdvancementCommand.Operation operation, ServerPlayerEntity serverPlayerEntity) {
+        for (Advancement advancement : advancements) {
+            operation.processEach(serverPlayerEntity, advancement);
+        }
+    }
+
+}

--- a/src/main/resources/apoli.accesswidener
+++ b/src/main/resources/apoli.accesswidener
@@ -3,3 +3,7 @@ accessWidener   v1  named
 mutable field net/minecraft/item/ItemStack item Lnet/minecraft/item/Item;
 extendable class net/minecraft/item/ItemStack
 accessible class net/minecraft/client/render/BackgroundRenderer$FogData
+accessible class net/minecraft/server/command/AdvancementCommand$Operation
+accessible class net/minecraft/server/command/AdvancementCommand$Selection
+accessible method net/minecraft/server/command/AdvancementCommand$Operation processEach (Lnet/minecraft/server/network/ServerPlayerEntity;Lnet/minecraft/advancement/Advancement;)Z
+accessible method net/minecraft/server/command/AdvancementCommand$Operation processEachCriterion (Lnet/minecraft/server/network/ServerPlayerEntity;Lnet/minecraft/advancement/Advancement;Ljava/lang/String;)Z

--- a/src/main/resources/apoli.mixins.json
+++ b/src/main/resources/apoli.mixins.json
@@ -6,6 +6,7 @@
   "mixins": [
     "AbstractBlockMixin",
     "AbstractBlockStateMixin",
+    "AdvancementCommandAccessor",
     "ArgumentTypesMixin",
     "BiomeBuilderMixin",
     "BiomeMixin",


### PR DESCRIPTION
This PR adds new fields to the `*_advancement` entity action types to make it functionally similar to the `/advancement` command:
* `criterion` and `criteria`; a string and a list of strings respectively to grant/revoke to/from the specified advancement (as long as the advancement has the string(s) as a criteria)
* `selection`; an enum for determining how to select the parent(s) and/or child(ren) of the specified advancement (or itself)