### PR TITLE
Significantly Improved ModifyPlayerSpawnPower

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/ModifyPlayerSpawnPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyPlayerSpawnPower.java
@@ -162,7 +162,7 @@ public class ModifyPlayerSpawnPower extends Power {
         int radius = ((ApoliConfig)Apoli.config).modifyPlayerSpawnPower.radius;
         int horizontalBlockCheckInterval = ((ApoliConfig)Apoli.config).modifyPlayerSpawnPower.horizontalBlockCheckInterval;
         int verticalBlockCheckInterval = ((ApoliConfig)Apoli.config).modifyPlayerSpawnPower.verticalBlockCheckInterval;
-        if (radius < 0 ) radius = 64;
+        if (radius < 0 ) radius = 6400;
         if (horizontalBlockCheckInterval <= 0) horizontalBlockCheckInterval = 64;
         if (verticalBlockCheckInterval <= 0) verticalBlockCheckInterval = 64;
         com.mojang.datafixers.util.Pair<BlockPos, RegistryEntry<Biome>> targetBiomePos = targetDimension.locateBiome(

--- a/src/main/java/io/github/apace100/apoli/power/ModifyPlayerSpawnPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyPlayerSpawnPower.java
@@ -2,6 +2,7 @@ package io.github.apace100.apoli.power;
 
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.util.ApoliConfig;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
@@ -158,12 +159,18 @@ public class ModifyPlayerSpawnPower extends Power {
             Apoli.LOGGER.warn("Power {} could not set {}'s spawnpoint at biome \"{}\" as it's not registered in dimension \"{}\".", this.getType().getIdentifier(), entity.getEntityName(), biomeId, dimension.getValue());
             return Optional.empty();
         }
+        int radius = ((ApoliConfig)Apoli.config).modifyPlayerSpawnPower.radius;
+        int horizontalBlockCheckInterval = ((ApoliConfig)Apoli.config).modifyPlayerSpawnPower.horizontalBlockCheckInterval;
+        int verticalBlockCheckInterval = ((ApoliConfig)Apoli.config).modifyPlayerSpawnPower.verticalBlockCheckInterval;
+        if (radius < 0 ) radius = 64;
+        if (horizontalBlockCheckInterval <= 0) horizontalBlockCheckInterval = 64;
+        if (verticalBlockCheckInterval <= 0) verticalBlockCheckInterval = 64;
         com.mojang.datafixers.util.Pair<BlockPos, RegistryEntry<Biome>> targetBiomePos = targetDimension.locateBiome(
                 biome -> biome.value() == targetBiome.get(),
                 originPos,
-                6400,
-                64,
-                64
+                radius,
+                horizontalBlockCheckInterval,
+                verticalBlockCheckInterval
         );
         if (targetBiomePos != null) return Optional.of(targetBiomePos.getFirst());
         else {

--- a/src/main/java/io/github/apace100/apoli/power/ModifyPlayerSpawnPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyPlayerSpawnPower.java
@@ -23,17 +23,18 @@ import net.minecraft.structure.StructureStart;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
 import net.minecraft.util.Unit;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraft.util.math.ChunkSectionPos;
-import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.*;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.source.BiomeCoords;
 import net.minecraft.world.gen.structure.Structure;
 import org.apache.commons.lang3.function.TriFunction;
 
+import java.util.Iterator;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 public class ModifyPlayerSpawnPower extends Power {
 
@@ -115,7 +116,7 @@ public class ModifyPlayerSpawnPower extends Power {
     }
 
     public Pair<ServerWorld, BlockPos> getSpawn(boolean isSpawnObstructed) {
-
+        Apoli.LOGGER.info("getSpawn");
         if (entity.getWorld().isClient || !(entity instanceof PlayerEntity playerEntity)) return null;
 
         ServerPlayerEntity serverPlayerEntity = (ServerPlayerEntity) playerEntity;
@@ -162,21 +163,18 @@ public class ModifyPlayerSpawnPower extends Power {
             Apoli.LOGGER.warn("Power {} could not set {}'s spawnpoint at biome \"{}\" as it's not registered in dimension \"{}\".", this.getType().getIdentifier(), entity.getEntityName(), biomeId, dimension.getValue());
             return Optional.empty();
         }
-
         com.mojang.datafixers.util.Pair<BlockPos, RegistryEntry<Biome>> targetBiomePos = targetDimension.locateBiome(
                 biome -> biome.value() == targetBiome.get(),
                 originPos,
                 6400,
-                8,
-                8
+                64,
+                64
         );
-
         if (targetBiomePos != null) return Optional.of(targetBiomePos.getFirst());
         else {
             Apoli.LOGGER.warn("Power {} could not set {}'s spawnpoint at biome \"{}\" as it couldn't be found in dimension \"{}\".", this.getType().getIdentifier(), entity.getEntityName(), biomeId, dimension.getValue());
             return Optional.empty();
         }
-
     }
 
     private Optional<Pair<BlockPos, Structure>> getStructurePos(World world, RegistryKey<Structure> structure, TagKey<Structure> structureTag, RegistryKey<World> dimension) {

--- a/src/main/java/io/github/apace100/apoli/power/ModifyPlayerSpawnPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyPlayerSpawnPower.java
@@ -26,15 +26,11 @@ import net.minecraft.util.Unit;
 import net.minecraft.util.math.*;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.source.BiomeCoords;
 import net.minecraft.world.gen.structure.Structure;
 import org.apache.commons.lang3.function.TriFunction;
 
-import java.util.Iterator;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 public class ModifyPlayerSpawnPower extends Power {
 
@@ -116,7 +112,6 @@ public class ModifyPlayerSpawnPower extends Power {
     }
 
     public Pair<ServerWorld, BlockPos> getSpawn(boolean isSpawnObstructed) {
-        Apoli.LOGGER.info("getSpawn");
         if (entity.getWorld().isClient || !(entity instanceof PlayerEntity playerEntity)) return null;
 
         ServerPlayerEntity serverPlayerEntity = (ServerPlayerEntity) playerEntity;

--- a/src/main/java/io/github/apace100/apoli/util/ApoliConfig.java
+++ b/src/main/java/io/github/apace100/apoli/util/ApoliConfig.java
@@ -8,9 +8,18 @@ public class ApoliConfig implements ConfigData {
     @ConfigEntry.Gui.CollapsibleObject
     public ExecuteCommand executeCommand = new ExecuteCommand();
 
+    @ConfigEntry.Gui.CollapsibleObject
+    public ModifyPlayerSpawnPower modifyPlayerSpawnPower = new ModifyPlayerSpawnPower();
+
     public static class ExecuteCommand {
         @ConfigEntry.BoundedDiscrete(min = 0, max = 4)
         public int permissionLevel = 2;
         public boolean showOutput = false;
+    }
+
+    public static class ModifyPlayerSpawnPower {
+        public int radius = 6400;
+        public int horizontalBlockCheckInterval = 64;
+        public int verticalBlockCheckInterval = 64;
     }
 }


### PR DESCRIPTION
The purpose of this pull request is to improve the ModifyPlayerSpawnPower as it was slow when it came to biomes that got farther away from spawn due to the function locateBiome() which checked every 8 blocks. locateBiome() now checks every 64 blocks, allowing it to check less frequently and thus find the specified biome much faster. 