### PR TITLE
Refactor `PowerTypes` and `ApoliDataTypes.POWER_TYPE`

### DIFF
--- a/src/main/java/io/github/apace100/apoli/Apoli.java
+++ b/src/main/java/io/github/apace100/apoli/Apoli.java
@@ -32,10 +32,10 @@ import net.fabricmc.fabric.api.resource.conditions.v1.ResourceConditions;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
-import net.minecraft.registry.Registry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -132,4 +132,5 @@ public class Apoli implements ModInitializer, EntityComponentInitializer, Ordere
 	public void registerResourceListeners(OrderedResourceListenerManager manager) {
 		manager.register(ResourceType.SERVER_DATA, new PowerTypes()).complete();
 	}
+
 }

--- a/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
+++ b/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableBiMap;
 import io.github.apace100.apoli.power.Active;
 import io.github.apace100.apoli.power.PowerType;
 import io.github.apace100.apoli.power.PowerTypeReference;
+import io.github.apace100.apoli.power.PowerTypeRegistry;
 import io.github.apace100.apoli.power.factory.action.ActionFactory;
 import io.github.apace100.apoli.power.factory.action.ActionType;
 import io.github.apace100.apoli.power.factory.action.ActionTypes;
@@ -44,11 +45,22 @@ import org.apache.commons.lang3.tuple.Triple;
 import java.util.EnumSet;
 import java.util.List;
 
+@SuppressWarnings("rawtypes")
 public class ApoliDataTypes {
 
-    public static final SerializableDataType<PowerTypeReference> POWER_TYPE = SerializableDataType.wrap(
-        PowerTypeReference.class, SerializableDataTypes.IDENTIFIER,
-        PowerType::getIdentifier, PowerTypeReference::new);
+    public static final SerializableDataType<PowerTypeReference> POWER_TYPE_REFERENCE = SerializableDataType.wrap(
+        PowerTypeReference.class,
+        SerializableDataTypes.IDENTIFIER,
+        PowerType::getIdentifier,
+        PowerTypeReference::new
+    );
+
+    public static final SerializableDataType<PowerType> POWER_TYPE = SerializableDataType.wrap(
+        PowerType.class,
+        SerializableDataTypes.IDENTIFIER,
+        PowerType::getIdentifier,
+        PowerTypeRegistry::get
+    );
 
     public static final SerializableDataType<ConditionFactory<Entity>.Instance> ENTITY_CONDITION =
         condition(ClassUtil.castClass(ConditionFactory.Instance.class), ConditionTypes.ENTITY);

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypeReference.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypeReference.java
@@ -9,12 +9,12 @@ import org.jetbrains.annotations.Nullable;
 public class PowerTypeReference<T extends Power> extends PowerType<T> {
 
     private PowerType<T> referencedPowerType;
-    private final Identifier currentId;
+    private final Identifier fileId;
     private final JsonElement jsonData;
 
-    protected PowerTypeReference(Identifier id, Identifier currentId, JsonElement jsonObject) {
+    protected PowerTypeReference(Identifier id, Identifier fileId, JsonElement jsonObject) {
         super(id, null);
-        this.currentId = currentId;
+        this.fileId = fileId;
         this.jsonData = jsonObject;
     }
 
@@ -55,8 +55,8 @@ public class PowerTypeReference<T extends Power> extends PowerType<T> {
     }
 
     @Nullable
-    protected Identifier getCurrentId() {
-        return currentId;
+    protected Identifier getFileId() {
+        return fileId;
     }
 
     public PowerType<T> getReferencedPowerType() {

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypeReference.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypeReference.java
@@ -1,15 +1,25 @@
 package io.github.apace100.apoli.power;
 
+import com.google.gson.JsonElement;
 import io.github.apace100.apoli.power.factory.PowerFactory;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
 public class PowerTypeReference<T extends Power> extends PowerType<T> {
 
     private PowerType<T> referencedPowerType;
+    private final Identifier currentId;
+    private final JsonElement jsonData;
+
+    protected PowerTypeReference(Identifier id, Identifier currentId, JsonElement jsonObject) {
+        super(id, null);
+        this.currentId = currentId;
+        this.jsonData = jsonObject;
+    }
 
     public PowerTypeReference(Identifier id) {
-        super(id, null);
+        this(id, null, null);
     }
 
     @Override
@@ -37,6 +47,16 @@ public class PowerTypeReference<T extends Power> extends PowerType<T> {
             return null;
         }
         return referencedPowerType.get(entity);
+    }
+
+    @Nullable
+    protected JsonElement getJsonData() {
+        return jsonData;
+    }
+
+    @Nullable
+    protected Identifier getCurrentId() {
+        return currentId;
     }
 
     public PowerType<T> getReferencedPowerType() {

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
@@ -40,6 +40,11 @@ public class PowerTypeRegistry {
         idToPower.remove(id);
     }
 
+    public static boolean isPreLoaded(Identifier id) {
+        return preLoadedPowers.stream()
+            .anyMatch(ref -> ref.getIdentifier().equals(id));
+    }
+
     public static boolean isDisabled(Identifier id) {
         return disabledPowers.contains(id);
     }


### PR DESCRIPTION
This PR refactors the `PowerTypes` class to pre-load and validate powers and the `ApoliDataTypes.POWER_TYPE` data type, where it now returns a `SerializableDataType<PowerType>` (previously `SerializableDataType<PowerTypeReference>`). This fixes issues like https://github.com/apace100/apoli/issues/56 by throwing an error early (on the apply phase of the resource listener for powers) instead of crashing the game

The way it works (currently) is it creates a `PowerTypeReference` and adds it to a list, which will contain the power's ID, the current ID (the power's ID without the sub-power key) and the power's JSON object, which will contain the power's data fields. The power is then validated after by parsing the JSON object using the power's factory instance and removed from the list