### PR TITLE
Fix #136

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
@@ -92,8 +92,9 @@ public abstract class GameRendererMixin {
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;pop()V", ordinal = 0))
     private void apoli$renderOverlayPowersBelowHud(float tickDelta, long startTime, boolean tick, CallbackInfo ci) {
 
-        //  Skip this method if the HUD is not hidden
-        if (!client.options.hudHidden) {
+        //  Skip this method if the HUD is not hidden or if the current screen is not null
+        //  (to make sure the overlay is not rendered twice)
+        if (!client.options.hudHidden || client.currentScreen != null) {
             return;
         }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
@@ -44,7 +44,7 @@ public abstract class GameRendererMixin {
 
     @Shadow
     @Final
-    private MinecraftClient client;
+    MinecraftClient client;
 
     @Shadow
     protected abstract void loadPostProcessor(Identifier identifier);
@@ -89,8 +89,25 @@ public abstract class GameRendererMixin {
         }
     }
 
+    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;pop()V", ordinal = 0))
+    private void apoli$renderOverlayPowersBelowHud(float tickDelta, long startTime, boolean tick, CallbackInfo ci) {
+
+        //  Skip this method if the HUD is not hidden
+        if (!client.options.hudHidden) {
+            return;
+        }
+
+        //  Otherwise, render overlay powers specified to render below the HUD
+        PowerHolderComponent.getPowers(client.getCameraEntity(), OverlayPower.class)
+            .stream()
+            .filter(p -> p.shouldRender(client.options, OverlayPower.DrawPhase.BELOW_HUD))
+            .sorted(Comparator.comparing(OverlayPower::getPriority))
+            .forEach(OverlayPower::render);
+
+    }
+
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;pop()V"))
-    private void renderOverlayPowers(float tickDelta, long startTime, boolean tick, CallbackInfo ci) {
+    private void apoli$renderOverlayPowersAboveHud(float tickDelta, long startTime, boolean tick, CallbackInfo ci) {
         PowerHolderComponent.getPowers(client.getCameraEntity(), OverlayPower.class)
             .stream()
             .filter(p -> p.shouldRender(client.options, OverlayPower.DrawPhase.ABOVE_HUD))

--- a/src/main/java/io/github/apace100/apoli/mixin/InGameHudMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/InGameHudMixin.java
@@ -28,12 +28,12 @@ public class InGameHudMixin {
     @Shadow @Final private MinecraftClient client;
 
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;getCurrentGameMode()Lnet/minecraft/world/GameMode;", ordinal = 0))
-    private void renderOnHud(DrawContext context, float tickDelta, CallbackInfo ci) {
+    private void apoli$renderOnHud(DrawContext context, float tickDelta, CallbackInfo ci) {
 
-        //  Render overlays below the HUD
+        //  Render overlay powers over the vanilla overlays and below the vanilla status bars
         PowerHolderComponent.getPowers(client.getCameraEntity(), OverlayPower.class)
             .stream()
-            .filter(overlayPower -> overlayPower.shouldRender(client.options, OverlayPower.DrawPhase.BELOW_HUD))
+            .filter(p -> p.shouldRender(client.options, OverlayPower.DrawPhase.BELOW_HUD))
             .sorted(Comparator.comparing(OverlayPower::getPriority))
             .forEach(OverlayPower::render);
 


### PR DESCRIPTION
This PR fixes https://github.com/apace100/apoli/issues/136 by rendering the overlays specified to render below the HUD *after* the `InGameHud#render` method is called if the HUD is hidden. The method for rendering the overlays in `InGameHud#render` is still there to render the overlays over the vanilla overlays and below the vanilla status bars