### PR TITLE
Add a prefix to all methods and variables used by Apoli's duck interfaces

### DIFF
--- a/src/main/java/io/github/apace100/apoli/access/BiomeWeatherAccess.java
+++ b/src/main/java/io/github/apace100/apoli/access/BiomeWeatherAccess.java
@@ -1,7 +1,6 @@
 package io.github.apace100.apoli.access;
 
 public interface BiomeWeatherAccess {
-
-    float getDownfall();
-    void setDownfall(float downfall);
+    float apoli$getDownfall();
+    void apoli$setDownfall(float downfall);
 }

--- a/src/main/java/io/github/apace100/apoli/access/EndRespawningEntity.java
+++ b/src/main/java/io/github/apace100/apoli/access/EndRespawningEntity.java
@@ -2,7 +2,7 @@ package io.github.apace100.apoli.access;
 
 public interface EndRespawningEntity {
 
-    void setEndRespawning(boolean endSpawn);
-    boolean isEndRespawning();
-    boolean hasRealRespawnPoint();
+    void apoli$setEndRespawning(boolean endSpawn);
+    boolean apoli$isEndRespawning();
+    boolean apoli$hasRealRespawnPoint();
 }

--- a/src/main/java/io/github/apace100/apoli/access/EntityLinkedItemStack.java
+++ b/src/main/java/io/github/apace100/apoli/access/EntityLinkedItemStack.java
@@ -3,9 +3,9 @@ package io.github.apace100.apoli.access;
 import net.minecraft.entity.Entity;
 
 public interface EntityLinkedItemStack {
-    Entity getEntity();
+    Entity apoli$getEntity();
 
-    Entity getEntity(boolean prioritiseVanillaHolder);
+    Entity apoli$getEntity(boolean prioritiseVanillaHolder);
 
-    void setEntity(Entity entity);
+    void apoli$setEntity(Entity entity);
 }

--- a/src/main/java/io/github/apace100/apoli/access/HiddenEffectStatus.java
+++ b/src/main/java/io/github/apace100/apoli/access/HiddenEffectStatus.java
@@ -3,5 +3,5 @@ package io.github.apace100.apoli.access;
 import net.minecraft.entity.effect.StatusEffectInstance;
 
 public interface HiddenEffectStatus {
-    StatusEffectInstance getHiddenEffect();
+    StatusEffectInstance apoli$getHiddenEffect();
 }

--- a/src/main/java/io/github/apace100/apoli/access/IdentifiedLootTable.java
+++ b/src/main/java/io/github/apace100/apoli/access/IdentifiedLootTable.java
@@ -5,7 +5,7 @@ import net.minecraft.util.Identifier;
 
 public interface IdentifiedLootTable {
 
-    void setId(Identifier id, LootManager lootManager);
+    void apoli$setId(Identifier id, LootManager lootManager);
 
-    Identifier getId();
+    Identifier apoli$getId();
 }

--- a/src/main/java/io/github/apace100/apoli/access/ModifiableFoodEntity.java
+++ b/src/main/java/io/github/apace100/apoli/access/ModifiableFoodEntity.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 public interface ModifiableFoodEntity {
 
-    ItemStack getOriginalFoodStack();
-    void setOriginalFoodStack(ItemStack original);
+    ItemStack apoli$getOriginalFoodStack();
+    void apoli$setOriginalFoodStack(ItemStack original);
 
-    List<ModifyFoodPower> getCurrentModifyFoodPowers();
-    void setCurrentModifyFoodPowers(List<ModifyFoodPower> powers);
+    List<ModifyFoodPower> apoli$getCurrentModifyFoodPowers();
+    void apoli$setCurrentModifyFoodPowers(List<ModifyFoodPower> powers);
 }

--- a/src/main/java/io/github/apace100/apoli/access/MovingEntity.java
+++ b/src/main/java/io/github/apace100/apoli/access/MovingEntity.java
@@ -2,5 +2,5 @@ package io.github.apace100.apoli.access;
 
 public interface MovingEntity {
 
-    boolean isMoving();
+    boolean apoli$isMoving();
 }

--- a/src/main/java/io/github/apace100/apoli/access/MutableItemStack.java
+++ b/src/main/java/io/github/apace100/apoli/access/MutableItemStack.java
@@ -5,7 +5,7 @@ import net.minecraft.item.ItemStack;
 
 public interface MutableItemStack {
 
-    void setItem(Item item);
+    void apoli$setItem(Item item);
 
-    void setFrom(ItemStack stack);
+    void apoli$setFrom(ItemStack stack);
 }

--- a/src/main/java/io/github/apace100/apoli/access/NameMutableDamageSource.java
+++ b/src/main/java/io/github/apace100/apoli/access/NameMutableDamageSource.java
@@ -2,6 +2,6 @@ package io.github.apace100.apoli.access;
 
 public interface NameMutableDamageSource {
 
-    void setName(String name);
+    void apoli$setName(String name);
 
 }

--- a/src/main/java/io/github/apace100/apoli/access/PowerCraftingInventory.java
+++ b/src/main/java/io/github/apace100/apoli/access/PowerCraftingInventory.java
@@ -4,6 +4,6 @@ import io.github.apace100.apoli.power.Power;
 
 public interface PowerCraftingInventory {
 
-    void setPower(Power power);
-    Power getPower();
+    void apoli$setPower(Power power);
+    Power apoli$getPower();
 }

--- a/src/main/java/io/github/apace100/apoli/access/PowerModifiedGrindstone.java
+++ b/src/main/java/io/github/apace100/apoli/access/PowerModifiedGrindstone.java
@@ -9,9 +9,9 @@ import java.util.Optional;
 
 public interface PowerModifiedGrindstone {
 
-    List<ModifyGrindstonePower> getAppliedPowers();
+    List<ModifyGrindstonePower> apoli$getAppliedPowers();
 
-    PlayerEntity getPlayer();
+    PlayerEntity apoli$getPlayer();
 
-    Optional<BlockPos> getPos();
+    Optional<BlockPos> apoli$getPos();
 }

--- a/src/main/java/io/github/apace100/apoli/access/ReplacingLootContext.java
+++ b/src/main/java/io/github/apace100/apoli/access/ReplacingLootContext.java
@@ -5,11 +5,11 @@ import net.minecraft.loot.context.LootContextType;
 
 public interface ReplacingLootContext {
 
-    void setType(LootContextType type);
+    void apoli$setType(LootContextType type);
 
-    LootContextType getType();
+    LootContextType apoli$getType();
 
-    void setReplaced(LootTable table);
+    void apoli$setReplaced(LootTable table);
 
-    boolean isReplaced(LootTable table);
+    boolean apoli$isReplaced(LootTable table);
 }

--- a/src/main/java/io/github/apace100/apoli/access/ReplacingLootContextParameterSet.java
+++ b/src/main/java/io/github/apace100/apoli/access/ReplacingLootContextParameterSet.java
@@ -4,8 +4,8 @@ import net.minecraft.loot.context.LootContextType;
 
 public interface ReplacingLootContextParameterSet {
 
-    void setType(LootContextType type);
+    void apoli$setType(LootContextType type);
 
-    LootContextType getType();
+    LootContextType apoli$getType();
 
 }

--- a/src/main/java/io/github/apace100/apoli/access/SubmergableEntity.java
+++ b/src/main/java/io/github/apace100/apoli/access/SubmergableEntity.java
@@ -5,7 +5,7 @@ import net.minecraft.registry.tag.TagKey;
 
 public interface SubmergableEntity {
 
-    boolean isSubmergedInLoosely(TagKey<Fluid> fluidTag);
+    boolean apoli$isSubmergedInLoosely(TagKey<Fluid> fluidTag);
 
-    double getFluidHeightLoosely(TagKey<Fluid> fluidTag);
+    double apoli$getFluidHeightLoosely(TagKey<Fluid> fluidTag);
 }

--- a/src/main/java/io/github/apace100/apoli/access/WaterMovingEntity.java
+++ b/src/main/java/io/github/apace100/apoli/access/WaterMovingEntity.java
@@ -2,5 +2,5 @@ package io.github.apace100.apoli.access;
 
 public interface WaterMovingEntity {
 
-    boolean isInMovementPhase();
+    boolean apoli$isInMovementPhase();
 }

--- a/src/main/java/io/github/apace100/apoli/data/DamageSourceDescription.java
+++ b/src/main/java/io/github/apace100/apoli/data/DamageSourceDescription.java
@@ -95,7 +95,7 @@ public class DamageSourceDescription {
     }
 
     private void overwriteDamageSourceMessageKey(DamageSource source) {
-        ((NameMutableDamageSource)source).setName(name);
+        ((NameMutableDamageSource)source).apoli$setName(name);
     }
 
     private void findBestMatchingDamageType(DamageSources damageSources) {

--- a/src/main/java/io/github/apace100/apoli/mixin/BiomeBuilderMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/BiomeBuilderMixin.java
@@ -16,6 +16,6 @@ public class BiomeBuilderMixin {
 
     @Inject(method = "build", at = @At("RETURN"))
     private void apoli$storeDownfall(CallbackInfoReturnable<Biome> cir) {
-        ((BiomeWeatherAccess)(Object)cir.getReturnValue()).setDownfall(downfall.floatValue());
+        ((BiomeWeatherAccess)(Object)cir.getReturnValue()).apoli$setDownfall(downfall.floatValue());
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/BiomeMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/BiomeMixin.java
@@ -12,12 +12,12 @@ public class BiomeMixin implements BiomeWeatherAccess {
     private float apoli$downfall;
 
     @Override
-    public float getDownfall() {
+    public float apoli$getDownfall() {
         return apoli$downfall;
     }
 
     @Override
-    public void setDownfall(float downfall) {
+    public void apoli$setDownfall(float downfall) {
         apoli$downfall = downfall;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ClientPlayerEntityMixin.java
@@ -12,11 +12,10 @@ import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerAbilities;
-import net.minecraft.network.encryption.PlayerPublicKey;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -27,7 +26,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(ClientPlayerEntity.class)
 public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity implements WaterMovingEntity {
 
-    private boolean isMoving = false;
+    @Unique
+    private boolean apoli$isMoving = false;
 
     @Shadow
     @Final
@@ -48,16 +48,17 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
 
     @Inject(at = @At("HEAD"), method = "tickMovement")
     private void beginMovementPhase(CallbackInfo ci) {
-        isMoving = true;
+        apoli$isMoving = true;
     }
 
     @Inject(at = @At("TAIL"), method = "tickMovement")
     private void endMovementPhase(CallbackInfo ci) {
-        isMoving = false;
+        apoli$isMoving = false;
     }
 
-    public boolean isInMovementPhase() {
-        return isMoving;
+    @Override
+    public boolean apoli$isInMovementPhase() {
+        return apoli$isMoving;
     }
 
     @Redirect(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerAbilities;getFlySpeed()F"))

--- a/src/main/java/io/github/apace100/apoli/mixin/CraftingInventoryMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/CraftingInventoryMixin.java
@@ -4,19 +4,21 @@ import io.github.apace100.apoli.access.PowerCraftingInventory;
 import io.github.apace100.apoli.power.Power;
 import net.minecraft.inventory.CraftingInventory;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(CraftingInventory.class)
 public class CraftingInventoryMixin implements PowerCraftingInventory {
 
+    @Unique
     private Power apoli$CachedPower;
 
     @Override
-    public void setPower(Power power) {
+    public void apoli$setPower(Power power) {
         apoli$CachedPower = power;
     }
 
     @Override
-    public Power getPower() {
+    public Power apoli$getPower() {
         return apoli$CachedPower;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/CraftingResultSlotMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/CraftingResultSlotMixin.java
@@ -30,7 +30,7 @@ public class CraftingResultSlotMixin {
             if (!player.getWorld().isClient)
             {
                 PowerCraftingInventory pci = (PowerCraftingInventory) craftingInventory;
-                if (pci.getPower() instanceof ModifyCraftingPower mcp)
+                if (pci.apoli$getPower() instanceof ModifyCraftingPower mcp)
                 {
                     Optional<BlockPos> blockPos = ModifiedCraftingRecipe.getBlockFromInventory(craftingInventory);
                     mcp.executeActions(blockPos);

--- a/src/main/java/io/github/apace100/apoli/mixin/CraftingScreenHandlerMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/CraftingScreenHandlerMixin.java
@@ -30,7 +30,7 @@ public class CraftingScreenHandlerMixin {
 
     @Inject(method = "updateResult", at = @At(value = "INVOKE", target = "Lnet/minecraft/recipe/RecipeManager;getFirstMatch(Lnet/minecraft/recipe/RecipeType;Lnet/minecraft/inventory/Inventory;Lnet/minecraft/world/World;)Ljava/util/Optional;"))
     private static void clearPowerCraftingInventory(ScreenHandler handler, World world, PlayerEntity player, RecipeInputInventory inventory, CraftingResultInventory resultInventory, CallbackInfo ci) {
-        if (inventory instanceof CraftingInventory craftingInventory) ((PowerCraftingInventory)craftingInventory).setPower(null);
+        if (inventory instanceof CraftingInventory craftingInventory) ((PowerCraftingInventory)craftingInventory).apoli$setPower(null);
     }
 
     @Inject(method = "canUse", at = @At("HEAD"), cancellable = true)
@@ -43,7 +43,7 @@ public class CraftingScreenHandlerMixin {
     @Inject(method = "quickMove", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;copy()Lnet/minecraft/item/ItemStack;", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
     private void modifyOutputItems(PlayerEntity player, int index, CallbackInfoReturnable<ItemStack> cir, ItemStack itemStack, Slot slot, ItemStack itemStack2) {
         if(input instanceof PowerCraftingInventory pci) {
-            if(pci.getPower() instanceof ModifyCraftingPower mcp) {
+            if(pci.apoli$getPower() instanceof ModifyCraftingPower mcp) {
                 mcp.applyAfterCraftingItemAction(itemStack2);
             }
         }

--- a/src/main/java/io/github/apace100/apoli/mixin/DamageSourceMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/DamageSourceMixin.java
@@ -15,7 +15,7 @@ public class DamageSourceMixin implements NameMutableDamageSource {
     private String apoli$mutableName;
 
     @Override
-    public void setName(String name) {
+    public void apoli$setName(String name) {
         apoli$mutableName = name;
     }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/EnchantmentHelperMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/EnchantmentHelperMixin.java
@@ -1,7 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
 import io.github.apace100.apoli.access.EntityLinkedItemStack;
-import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.ModifyEnchantmentLevelPower;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -22,7 +21,7 @@ public class EnchantmentHelperMixin {
 
     @Redirect(method = "forEachEnchantment(Lnet/minecraft/enchantment/EnchantmentHelper$Consumer;Lnet/minecraft/item/ItemStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
     private static boolean forEachIsEmpty(ItemStack instance) {
-        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
+        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
             return false;
         }
         return instance.isEmpty();
@@ -51,7 +50,7 @@ public class EnchantmentHelperMixin {
 
     @Redirect(method = "getLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
     private static boolean getLevelIsEmpty(ItemStack instance) {
-        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
+        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
             return false;
         }
         return instance.isEmpty();
@@ -64,7 +63,7 @@ public class EnchantmentHelperMixin {
 
     @Redirect(method = "chooseEquipmentWith(Lnet/minecraft/enchantment/Enchantment;Lnet/minecraft/entity/LivingEntity;Ljava/util/function/Predicate;)Ljava/util/Map$Entry;", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
     private static boolean allowEmptyEquipmentChoosing(ItemStack instance) {
-        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
+        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
             return false;
         }
         return instance.isEmpty();

--- a/src/main/java/io/github/apace100/apoli/mixin/EnchantmentMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/EnchantmentMixin.java
@@ -1,8 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
-import com.terraformersmc.modmenu.util.mod.Mod;
 import io.github.apace100.apoli.access.EntityLinkedItemStack;
-import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.ModifyEnchantmentLevelPower;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EquipmentSlot;
@@ -30,7 +28,7 @@ public class EnchantmentMixin {
 
     @Redirect(method = "getEquipment", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
     private boolean allowEmptySlotItemIfModified(ItemStack instance) {
-        if (this.apoli$capturedItem != null && this.apoli$capturedItem.isEmpty() && ((EntityLinkedItemStack)apoli$capturedItem).getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
+        if (this.apoli$capturedItem != null && this.apoli$capturedItem.isEmpty() && ((EntityLinkedItemStack)apoli$capturedItem).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
             return false;
         }
         return instance.isEmpty();

--- a/src/main/java/io/github/apace100/apoli/mixin/EntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/EntityMixin.java
@@ -12,7 +12,6 @@ import net.fabricmc.api.Environment;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.MovementType;
@@ -31,8 +30,10 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -68,7 +69,10 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
     @Shadow
     protected boolean onGround;
 
-    @Shadow @Nullable protected Set<TagKey<Fluid>> submergedFluidTag;
+    @Final
+    @Shadow
+    @Nullable
+    private Set<TagKey<Fluid>> submergedFluidTag;
 
     @Shadow protected Object2DoubleMap<TagKey<Fluid>> fluidHeight;
 
@@ -76,7 +80,7 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
     private void makeEntitiesIgnoreWater(CallbackInfoReturnable<Boolean> cir) {
         if(PowerHolderComponent.hasPower((Entity)(Object)this, IgnoreWaterPower.class)) {
             if(this instanceof WaterMovingEntity) {
-                if(((WaterMovingEntity)this).isInMovementPhase()) {
+                if(((WaterMovingEntity)this).apoli$isInMovementPhase()) {
                     cir.setReturnValue(false);
                 }
             }
@@ -134,19 +138,21 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
         return state.getCollisionShape(world, pos, ShapeContext.of((Entity)(Object)this));
     }
 
-    private boolean isMoving;
-    private float distanceBefore;
+    @Unique
+    private boolean apoli$isMoving;
+    @Unique
+    private float apoli$distanceBefore;
 
     @Inject(method = "move", at = @At("HEAD"))
     private void saveDistanceTraveled(MovementType type, Vec3d movement, CallbackInfo ci) {
-        this.isMoving = false;
-        this.distanceBefore = this.distanceTraveled;
+        this.apoli$isMoving = false;
+        this.apoli$distanceBefore = this.distanceTraveled;
     }
 
     @Inject(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiler/Profiler;pop()V"))
     private void checkIsMoving(MovementType type, Vec3d movement, CallbackInfo ci) {
-        if (this.distanceTraveled > this.distanceBefore) {
-            this.isMoving = true;
+        if (this.distanceTraveled > this.apoli$distanceBefore) {
+            this.apoli$isMoving = true;
         }
     }
 
@@ -171,7 +177,7 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
     }
 
     @Override
-    public boolean isSubmergedInLoosely(TagKey<Fluid> tag) {
+    public boolean apoli$isSubmergedInLoosely(TagKey<Fluid> tag) {
         if(tag == null || submergedFluidTag == null) {
             return false;
         }
@@ -183,7 +189,7 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
     }
 
     @Override
-    public double getFluidHeightLoosely(TagKey<Fluid> tag) {
+    public double apoli$getFluidHeightLoosely(TagKey<Fluid> tag) {
         if(tag == null) {
             return 0;
         }
@@ -199,8 +205,8 @@ public abstract class EntityMixin implements MovingEntity, SubmergableEntity {
     }
 
     @Override
-    public boolean isMoving() {
-        return isMoving;
+    public boolean apoli$isMoving() {
+        return apoli$isMoving;
     }
 
     @Environment(EnvType.CLIENT)

--- a/src/main/java/io/github/apace100/apoli/mixin/GrindstoneScreenHandlerBottomInputSlotMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GrindstoneScreenHandlerBottomInputSlotMixin.java
@@ -22,7 +22,7 @@ public class GrindstoneScreenHandlerBottomInputSlotMixin {
     @Inject(method = "canInsert", at = @At("HEAD"), cancellable = true)
     private void allowPowerStacks(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
         PowerModifiedGrindstone pmg = (PowerModifiedGrindstone) field_16778;
-        if(PowerHolderComponent.hasPower(pmg.getPlayer(), ModifyGrindstonePower.class, p -> p.allowsInBottom(stack))) {
+        if(PowerHolderComponent.hasPower(pmg.apoli$getPlayer(), ModifyGrindstonePower.class, p -> p.allowsInBottom(stack))) {
             cir.setReturnValue(true);
         }
     }

--- a/src/main/java/io/github/apace100/apoli/mixin/GrindstoneScreenHandlerMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GrindstoneScreenHandlerMixin.java
@@ -69,17 +69,17 @@ public abstract class GrindstoneScreenHandlerMixin extends ScreenHandler impleme
     }
 
     @Override
-    public List<ModifyGrindstonePower> getAppliedPowers() {
+    public List<ModifyGrindstonePower> apoli$getAppliedPowers() {
         return apoli$appliedPowers;
     }
 
     @Override
-    public PlayerEntity getPlayer() {
+    public PlayerEntity apoli$getPlayer() {
         return apoli$cachedPlayer;
     }
 
     @Override
-    public Optional<BlockPos> getPos() {
+    public Optional<BlockPos> apoli$getPos() {
         return apoli$cachedPosition;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/GrindstoneScreenHandlerOutputSlotMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GrindstoneScreenHandlerOutputSlotMixin.java
@@ -1,8 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
-import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.access.PowerModifiedGrindstone;
-import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.ModifyGrindstonePower;
 import io.github.apace100.apoli.util.modifier.Modifier;
 import io.github.apace100.apoli.util.modifier.ModifierUtil;
@@ -31,24 +29,24 @@ public class GrindstoneScreenHandlerOutputSlotMixin {
     @Inject(method = "onTakeItem", at = @At(value = "INVOKE",target = "Lnet/minecraft/inventory/Inventory;setStack(ILnet/minecraft/item/ItemStack;)V", ordinal = 0))
     private void executeGrindstoneActions(PlayerEntity player, ItemStack stack, CallbackInfo ci) {
         PowerModifiedGrindstone pmg = (PowerModifiedGrindstone) field_16780;
-        List<ModifyGrindstonePower> applyingPowers = pmg.getAppliedPowers();
+        List<ModifyGrindstonePower> applyingPowers = pmg.apoli$getAppliedPowers();
         applyingPowers.forEach(mgp -> {
             mgp.applyAfterGrindingItemAction(stack);
-            mgp.executeActions(pmg.getPos());
+            mgp.executeActions(pmg.apoli$getPos());
         });
     }
 
     @Inject(method = "getExperience(Lnet/minecraft/world/World;)I", at = @At("RETURN"), cancellable = true)
     private void modifyExperience(World world, CallbackInfoReturnable<Integer> cir) {
         PowerModifiedGrindstone pmg = (PowerModifiedGrindstone) field_16780;
-        if(pmg.getAppliedPowers().size() == 0) {
+        if(pmg.apoli$getAppliedPowers().size() == 0) {
             return;
         }
-        List<Modifier> modifiers = pmg.getAppliedPowers().stream().map(ModifyGrindstonePower::getExperienceModifier).filter(Objects::nonNull).toList();
+        List<Modifier> modifiers = pmg.apoli$getAppliedPowers().stream().map(ModifyGrindstonePower::getExperienceModifier).filter(Objects::nonNull).toList();
         if(modifiers.size() == 0) {
             return;
         }
-        int xp = (int)ModifierUtil.applyModifiers(pmg.getPlayer(), modifiers, cir.getReturnValue());
+        int xp = (int)ModifierUtil.applyModifiers(pmg.apoli$getPlayer(), modifiers, cir.getReturnValue());
         cir.setReturnValue(xp);
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/GrindstoneScreenHandlerTopInputSlotMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GrindstoneScreenHandlerTopInputSlotMixin.java
@@ -22,7 +22,7 @@ public class GrindstoneScreenHandlerTopInputSlotMixin {
     @Inject(method = "canInsert", at = @At("HEAD"), cancellable = true)
     private void allowPowerStacks(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
         PowerModifiedGrindstone pmg = (PowerModifiedGrindstone) field_16777;
-        if(PowerHolderComponent.hasPower(pmg.getPlayer(), ModifyGrindstonePower.class, p -> p.allowsInTop(stack))) {
+        if(PowerHolderComponent.hasPower(pmg.apoli$getPlayer(), ModifyGrindstonePower.class, p -> p.allowsInTop(stack))) {
             cir.setReturnValue(true);
         }
     }

--- a/src/main/java/io/github/apace100/apoli/mixin/HungerManagerMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/HungerManagerMixin.java
@@ -40,7 +40,7 @@ public class HungerManagerMixin {
 
         if (player == null) return baseValue;
 
-        List<Modifier> modifiers = ((ModifiableFoodEntity) player).getCurrentModifyFoodPowers()
+        List<Modifier> modifiers = ((ModifiableFoodEntity) player).apoli$getCurrentModifyFoodPowers()
             .stream()
             .filter(p -> p.doesApply(stack))
             .flatMap(p -> p.getFoodModifiers().stream())
@@ -59,7 +59,7 @@ public class HungerManagerMixin {
         float baseValue = foodComponent.getSaturationModifier();
         if (player == null) return baseValue;
 
-        List<Modifier> modifiers = ((ModifiableFoodEntity) player).getCurrentModifyFoodPowers()
+        List<Modifier> modifiers = ((ModifiableFoodEntity) player).apoli$getCurrentModifyFoodPowers()
             .stream()
             .filter(p -> p.doesApply(stack))
             .flatMap(p -> p.getSaturationModifiers().stream())
@@ -77,7 +77,7 @@ public class HungerManagerMixin {
 
         if (player == null || player.getWorld().isClient) return;
 
-        ((ModifiableFoodEntity) player).getCurrentModifyFoodPowers()
+        ((ModifiableFoodEntity) player).apoli$getCurrentModifyFoodPowers()
             .stream()
             .filter(p -> p.doesApply(stack))
             .forEach(ModifyFoodPower::eat);

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -46,12 +46,12 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
     private Entity apoli$holdingEntity;
 
     @Override
-    public Entity getEntity() {
-        return getEntity(true);
+    public Entity apoli$getEntity() {
+        return apoli$getEntity(true);
     }
 
     @Override
-    public Entity getEntity(boolean prioritiseVanillaHolder) {
+    public Entity apoli$getEntity(boolean prioritiseVanillaHolder) {
         Entity vanillaHolder = getHolder();
         if(!prioritiseVanillaHolder || vanillaHolder == null) {
             return apoli$holdingEntity;
@@ -60,14 +60,14 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
     }
 
     @Override
-    public void setEntity(Entity entity) {
+    public void apoli$setEntity(Entity entity) {
         this.apoli$holdingEntity = entity;
     }
 
     @Inject(method = "copy", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;setBobbingAnimationTime(I)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
     private void copyNewParams(CallbackInfoReturnable<ItemStack> cir, ItemStack itemStack) {
         if (this.apoli$holdingEntity != null) {
-            ((EntityLinkedItemStack)itemStack).setEntity(apoli$holdingEntity);
+            ((EntityLinkedItemStack)itemStack).apoli$setEntity(apoli$holdingEntity);
         }
     }
 
@@ -160,15 +160,15 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
     }
 
     @Override
-    public void setItem(Item item) {
+    public void apoli$setItem(Item item) {
         this.item = item;
     }
 
     @Override
-    public void setFrom(ItemStack stack) {
-        setItem(stack.getItem());
+    public void apoli$setFrom(ItemStack stack) {
+        apoli$setItem(stack.getItem());
         nbt = stack.getNbt();
         count = stack.getCount();
-        setEntity(((EntityLinkedItemStack)stack).getEntity(false));
+        apoli$setEntity(((EntityLinkedItemStack)stack).apoli$getEntity(false));
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/LivingEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LivingEntityMixin.java
@@ -107,7 +107,7 @@ public abstract class LivingEntityMixin extends Entity implements ModifiableFood
                     effect.isAmbient(),
                     effect.shouldShowParticles(),
                     effect.shouldShowIcon(),
-                    ((HiddenEffectStatus) effect).getHiddenEffect(),
+                    ((HiddenEffectStatus) effect).apoli$getHiddenEffect(),
                     Optional.empty()
             );
         }
@@ -435,17 +435,17 @@ public abstract class LivingEntityMixin extends Entity implements ModifiableFood
         for(ModifyFoodPower mfp : mfps) {
             newStack = mfp.getConsumedItemStack(newStack);
         }
-        ((ModifiableFoodEntity)this).setCurrentModifyFoodPowers(mfps);
-        ((ModifiableFoodEntity)this).setOriginalFoodStack(original);
+        ((ModifiableFoodEntity)this).apoli$setCurrentModifyFoodPowers(mfps);
+        ((ModifiableFoodEntity)this).apoli$setOriginalFoodStack(original);
         return newStack;
     }
 
     @ModifyVariable(method = "eatFood", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;applyFoodEffects(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/entity/LivingEntity;)V", shift = At.Shift.AFTER))
     private ItemStack unmodifyEatenItemStack(ItemStack modified) {
         ModifiableFoodEntity foodEntity = (ModifiableFoodEntity)this;
-        ItemStack original = foodEntity.getOriginalFoodStack();
+        ItemStack original = foodEntity.apoli$getOriginalFoodStack();
         if(original != null) {
-            foodEntity.setOriginalFoodStack(null);
+            foodEntity.apoli$setOriginalFoodStack(null);
             return original;
         }
         return modified;
@@ -453,12 +453,12 @@ public abstract class LivingEntityMixin extends Entity implements ModifiableFood
 
     @Inject(method = "eatFood", at = @At("TAIL"))
     private void removeCurrentModifyFoodPowers(World world, ItemStack stack, CallbackInfoReturnable<ItemStack> cir) {
-        setCurrentModifyFoodPowers(new LinkedList<>());
+        apoli$setCurrentModifyFoodPowers(new LinkedList<>());
     }
 
     @Redirect(method = "eatFood", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;applyFoodEffects(Lnet/minecraft/item/ItemStack;Lnet/minecraft/world/World;Lnet/minecraft/entity/LivingEntity;)V"))
     private void preventApplyingFoodEffects(LivingEntity livingEntity, ItemStack stack, World world, LivingEntity targetEntity) {
-        if(getCurrentModifyFoodPowers().stream().anyMatch(ModifyFoodPower::doesPreventEffects)) {
+        if(apoli$getCurrentModifyFoodPowers().stream().anyMatch(ModifyFoodPower::doesPreventEffects)) {
             return;
         }
         this.applyFoodEffects(stack, world, targetEntity);
@@ -497,27 +497,27 @@ public abstract class LivingEntityMixin extends Entity implements ModifiableFood
     private ItemStack apoli$originalFoodStack;
 
     @Override
-    public List<ModifyFoodPower> getCurrentModifyFoodPowers() {
+    public List<ModifyFoodPower> apoli$getCurrentModifyFoodPowers() {
         return apoli$currentModifyFoodPowers;
     }
 
     @Override
-    public void setCurrentModifyFoodPowers(List<ModifyFoodPower> powers) {
+    public void apoli$setCurrentModifyFoodPowers(List<ModifyFoodPower> powers) {
         apoli$currentModifyFoodPowers = powers;
     }
 
     @Override
-    public ItemStack getOriginalFoodStack() {
+    public ItemStack apoli$getOriginalFoodStack() {
         return apoli$originalFoodStack;
     }
 
     @Override
-    public void setOriginalFoodStack(ItemStack original) {
+    public void apoli$setOriginalFoodStack(ItemStack original) {
         apoli$originalFoodStack = original;
     }
 
     @Inject(method = "baseTick", at = @At("TAIL"))
     private void updateItemStackHolder(CallbackInfo ci) {
-        InventoryUtil.forEachStack(this, stack -> ((EntityLinkedItemStack) stack).setEntity(this), stack -> ((EntityLinkedItemStack) stack).setEntity(this));
+        InventoryUtil.forEachStack(this, stack -> ((EntityLinkedItemStack) stack).apoli$setEntity(this), stack -> ((EntityLinkedItemStack) stack).apoli$setEntity(this));
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/LoginMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LoginMixin.java
@@ -78,7 +78,7 @@ public abstract class LoginMixin {
 	private void preventEndExitSpawnPointSetting(ServerPlayerEntity serverPlayerEntity, RegistryKey<World> dimension, BlockPos pos, float angle, boolean spawnPointSet, boolean bl, ServerPlayerEntity playerEntity, boolean alive) {
 		EndRespawningEntity ere = (EndRespawningEntity)playerEntity;
 		// Prevent setting the spawn point if the player has a "fake" respawn point
-		if(ere.hasRealRespawnPoint()) {
+		if(ere.apoli$hasRealRespawnPoint()) {
 			serverPlayerEntity.setSpawnPoint(dimension, pos, angle, spawnPointSet, bl);
 		}
 	}

--- a/src/main/java/io/github/apace100/apoli/mixin/LootContextBuilderMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LootContextBuilderMixin.java
@@ -4,7 +4,6 @@ import io.github.apace100.apoli.access.ReplacingLootContext;
 import io.github.apace100.apoli.access.ReplacingLootContextParameterSet;
 import net.minecraft.loot.context.LootContext;
 import net.minecraft.loot.context.LootContextParameterSet;
-import net.minecraft.loot.context.LootContextType;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,6 +22,6 @@ public class LootContextBuilderMixin {
         ReplacingLootContextParameterSet rlcps = (ReplacingLootContextParameterSet) parameters;
 
         ReplacingLootContext rlc = (ReplacingLootContext) cir.getReturnValue();
-        rlc.setType(rlcps.getType());
+        rlc.apoli$setType(rlcps.apoli$getType());
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/LootContextMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LootContextMixin.java
@@ -6,7 +6,6 @@ import net.minecraft.loot.context.LootContext;
 import net.minecraft.loot.context.LootContextType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.Inject;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -21,22 +20,22 @@ public class LootContextMixin implements ReplacingLootContext {
     private final Set<LootTable> apoli$replacedTables = new HashSet<>();
 
     @Override
-    public void setType(LootContextType type) {
+    public void apoli$setType(LootContextType type) {
         apoli$lootContextType = type;
     }
 
     @Override
-    public LootContextType getType() {
+    public LootContextType apoli$getType() {
         return apoli$lootContextType;
     }
 
     @Override
-    public void setReplaced(LootTable table) {
+    public void apoli$setReplaced(LootTable table) {
         apoli$replacedTables.add(table);
     }
 
     @Override
-    public boolean isReplaced(LootTable table) {
+    public boolean apoli$isReplaced(LootTable table) {
         return apoli$replacedTables.contains(table);
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/LootContextParameterSetBuilderMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LootContextParameterSetBuilderMixin.java
@@ -14,6 +14,6 @@ public class LootContextParameterSetBuilderMixin {
     @Inject(method = "build", at = @At("RETURN"))
     private void setLootContextType(LootContextType type, CallbackInfoReturnable<LootContext> cir) {
         ReplacingLootContextParameterSet rlc = (ReplacingLootContextParameterSet) cir.getReturnValue();
-        rlc.setType(type);
+        rlc.apoli$setType(type);
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/LootContextParameterSetMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LootContextParameterSetMixin.java
@@ -13,12 +13,12 @@ public class LootContextParameterSetMixin implements ReplacingLootContextParamet
     private LootContextType apoli$lootContextType;
 
     @Override
-    public void setType(LootContextType type) {
+    public void apoli$setType(LootContextType type) {
         apoli$lootContextType = type;
     }
 
     @Override
-    public LootContextType getType() {
+    public LootContextType apoli$getType() {
         return apoli$lootContextType;
     }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/LootDataLookupMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LootDataLookupMixin.java
@@ -9,12 +9,10 @@ import net.minecraft.loot.LootManager;
 import net.minecraft.loot.LootTable;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Map;
 import java.util.Optional;
 
 @Mixin(LootDataLookup.class)
@@ -24,7 +22,7 @@ public interface LootDataLookupMixin extends LootDataLookup
     private void setTableId(Identifier id, CallbackInfoReturnable<LootTable> cir) {
         if(id.equals(ReplaceLootTablePower.REPLACED_TABLE_UTIL_ID)) {
             LootTable replace = ReplaceLootTablePower.peek();
-            Apoli.LOGGER.info("Replacing " + id + " with " + ((IdentifiedLootTable)replace).getId());
+            Apoli.LOGGER.info("Replacing " + id + " with " + ((IdentifiedLootTable)replace).apoli$getId());
             cir.setReturnValue(replace);
             //cir.setReturnValue(getTable(ReplaceLootTablePower.LAST_REPLACED_TABLE_ID));
         } else {
@@ -32,7 +30,7 @@ public interface LootDataLookupMixin extends LootDataLookup
             if(tableOptional.isPresent()) {
                 LootTable table = tableOptional.get();
                 if(table instanceof IdentifiedLootTable identifiedLootTable) {
-                    identifiedLootTable.setId(id, (LootManager)(Object)this);
+                    identifiedLootTable.apoli$setId(id, (LootManager)(Object)this);
                 }
             }
         }

--- a/src/main/java/io/github/apace100/apoli/mixin/LootTableMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/LootTableMixin.java
@@ -1,7 +1,5 @@
 package io.github.apace100.apoli.mixin;
 
-import com.google.common.collect.Lists;
-import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.access.IdentifiedLootTable;
 import io.github.apace100.apoli.access.ReplacingLootContext;
 import io.github.apace100.apoli.component.PowerHolderComponent;
@@ -39,23 +37,23 @@ public class LootTableMixin implements IdentifiedLootTable {
     private LootManager apoli$lootManager;
 
     @Override
-    public void setId(Identifier id, LootManager lootManager) {
+    public void apoli$setId(Identifier id, LootManager lootManager) {
         apoli$id = id;
         apoli$lootManager = lootManager;
     }
 
     @Override
-    public Identifier getId() {
+    public Identifier apoli$getId() {
         return apoli$id;
     }
 
     @Inject(method = "generateUnprocessedLoot(Lnet/minecraft/loot/context/LootContext;Ljava/util/function/Consumer;)V", at = @At("HEAD"), cancellable = true)
     private void modifyLootTable(LootContext context, Consumer<ItemStack> lootConsumer, CallbackInfo ci) {
-        if(((ReplacingLootContext)context).isReplaced((LootTable)(Object)this)) {
+        if(((ReplacingLootContext)context).apoli$isReplaced((LootTable)(Object)this)) {
             return;
         }
         if(context.hasParameter(LootContextParameters.THIS_ENTITY)) {
-            LootContextType type = ((ReplacingLootContext)context).getType();
+            LootContextType type = ((ReplacingLootContext)context).apoli$getType();
             Entity entity = context.get(LootContextParameters.THIS_ENTITY);
             if(type == LootContextTypes.FISHING) {
                 if(entity instanceof FishingBobberEntity bobber) {
@@ -88,7 +86,7 @@ public class LootTableMixin implements IdentifiedLootTable {
                 replacement = apoli$lootManager.getLootTable(id);
                 ReplaceLootTablePower.addToStack(replacement);
             }
-            ((ReplacingLootContext)context).setReplaced((LootTable)(Object)this);
+            ((ReplacingLootContext)context).apoli$setReplaced((LootTable)(Object)this);
             replacement.generateUnprocessedLoot(context, lootConsumer);
             ReplaceLootTablePower.clearStack();
             ci.cancel();

--- a/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
@@ -33,8 +33,6 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -79,8 +77,8 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Nameable
         for(ModifyFoodPower mfp : mfps) {
             newStack = mfp.getConsumedItemStack(newStack);
         }
-        ((ModifiableFoodEntity)this).setCurrentModifyFoodPowers(mfps);
-        ((ModifiableFoodEntity)this).setOriginalFoodStack(original);
+        ((ModifiableFoodEntity)this).apoli$setCurrentModifyFoodPowers(mfps);
+        ((ModifiableFoodEntity)this).apoli$setOriginalFoodStack(original);
         return newStack;
     }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ServerPlayNetworkHandlerMixin.java
@@ -21,12 +21,12 @@ public class ServerPlayNetworkHandlerMixin {
 
     @Inject(method = "onClientStatus", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/PlayerManager;respawnPlayer(Lnet/minecraft/server/network/ServerPlayerEntity;Z)Lnet/minecraft/server/network/ServerPlayerEntity;", ordinal = 0))
     private void saveEndRespawnStatus(ClientStatusC2SPacket packet, CallbackInfo ci) {
-        ((EndRespawningEntity)this.player).setEndRespawning(true);
+        ((EndRespawningEntity)this.player).apoli$setEndRespawning(true);
     }
 
     @Inject(method = "onClientStatus", at = @At(value = "INVOKE", target = "Lnet/minecraft/advancement/criterion/ChangedDimensionCriterion;trigger(Lnet/minecraft/server/network/ServerPlayerEntity;Lnet/minecraft/registry/RegistryKey;Lnet/minecraft/registry/RegistryKey;)V"))
     private void undoEndRespawnStatus(ClientStatusC2SPacket packet, CallbackInfo ci) {
-        ((EndRespawningEntity)this.player).setEndRespawning(false);
+        ((EndRespawningEntity)this.player).apoli$setEndRespawning(false);
     }
 
     @Inject(method = "onUpdateSelectedSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/packet/c2s/play/UpdateSelectedSlotC2SPacket;getSelectedSlot()I", ordinal = 0))

--- a/src/main/java/io/github/apace100/apoli/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ServerPlayerEntityMixin.java
@@ -101,7 +101,7 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Sc
 
     @Inject(at = @At("HEAD"), method = "getSpawnPointDimension", cancellable = true)
     private void modifySpawnPointDimension(CallbackInfoReturnable<RegistryKey<World>> info) {
-        if (!this.origins_isEndRespawning && (spawnPointPosition == null || hasObstructedSpawn()) && PowerHolderComponent.getPowers(this, ModifyPlayerSpawnPower.class).size() > 0) {
+        if (!this.apoli$isEndRespawning && (spawnPointPosition == null || hasObstructedSpawn()) && PowerHolderComponent.getPowers(this, ModifyPlayerSpawnPower.class).size() > 0) {
             ModifyPlayerSpawnPower power = PowerHolderComponent.getPowers(this, ModifyPlayerSpawnPower.class).get(0);
             info.setReturnValue(power.dimension);
         }
@@ -109,7 +109,7 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Sc
 
     @Inject(at = @At("HEAD"), method = "getSpawnPointPosition", cancellable = true)
     private void modifyPlayerSpawnPosition(CallbackInfoReturnable<BlockPos> info) {
-        if(!this.origins_isEndRespawning && PowerHolderComponent.getPowers(this, ModifyPlayerSpawnPower.class).size() > 0) {
+        if(!this.apoli$isEndRespawning && PowerHolderComponent.getPowers(this, ModifyPlayerSpawnPower.class).size() > 0) {
             if(spawnPointPosition == null) {
                 info.setReturnValue(findPlayerSpawn());
             } else if(hasObstructedSpawn()) {
@@ -122,7 +122,7 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Sc
 
     @Inject(at = @At("HEAD"), method = "isSpawnForced", cancellable = true)
     private void modifySpawnPointSet(CallbackInfoReturnable<Boolean> info) {
-        if(!this.origins_isEndRespawning && (spawnPointPosition == null || hasObstructedSpawn()) && PowerHolderComponent.hasPower(this, ModifyPlayerSpawnPower.class)) {
+        if(!this.apoli$isEndRespawning && (spawnPointPosition == null || hasObstructedSpawn()) && PowerHolderComponent.hasPower(this, ModifyPlayerSpawnPower.class)) {
             info.setReturnValue(true);
         }
     }
@@ -169,20 +169,20 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Sc
     }
 
     @Unique
-    private boolean origins_isEndRespawning;
+    private boolean apoli$isEndRespawning;
 
     @Override
-    public void setEndRespawning(boolean endSpawn) {
-        this.origins_isEndRespawning = endSpawn;
+    public void apoli$setEndRespawning(boolean endSpawn) {
+        this.apoli$isEndRespawning = endSpawn;
     }
 
     @Override
-    public boolean isEndRespawning() {
-        return this.origins_isEndRespawning;
+    public boolean apoli$isEndRespawning() {
+        return this.apoli$isEndRespawning;
     }
 
     @Override
-    public boolean hasRealRespawnPoint() {
+    public boolean apoli$hasRealRespawnPoint() {
         return spawnPointPosition != null && !hasObstructedSpawn();
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/StatusEffectInstanceMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/StatusEffectInstanceMixin.java
@@ -12,7 +12,7 @@ public class StatusEffectInstanceMixin implements HiddenEffectStatus {
     @Nullable
     private StatusEffectInstance hiddenEffect;
 
-    public @Nullable StatusEffectInstance getHiddenEffect() {
+    public @Nullable StatusEffectInstance apoli$getHiddenEffect() {
         return this.hiddenEffect;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/ModifyEnchantmentLevelPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyEnchantmentLevelPower.java
@@ -80,7 +80,7 @@ public class ModifyEnchantmentLevelPower extends ValueModifyingPower {
     }
 
     private static NbtList generateEnchantments(NbtList enchants, ItemStack self) {
-        Entity entity = ((EntityLinkedItemStack) self).getEntity();
+        Entity entity = ((EntityLinkedItemStack) self).apoli$getEntity();
 
         if(!(entity instanceof LivingEntity living)) return enchants;
 
@@ -113,7 +113,7 @@ public class ModifyEnchantmentLevelPower extends ValueModifyingPower {
     }
 
     public static NbtList getEnchantments(ItemStack self, NbtList originalTag) {
-        Entity entity = ((EntityLinkedItemStack) self).getEntity();
+        Entity entity = ((EntityLinkedItemStack) self).apoli$getEntity();
         if (entity instanceof LivingEntity living && ENTITY_ITEM_ENCHANTS.containsKey(entity)) {
             ConcurrentHashMap<ItemStack, NbtList> itemEnchants = ENTITY_ITEM_ENCHANTS.get(entity);
             if (shouldReapplyEnchantments(living, self)) {
@@ -141,7 +141,7 @@ public class ModifyEnchantmentLevelPower extends ValueModifyingPower {
 
     public static Map<Enchantment, Integer> get(ItemStack self, boolean useModifications) {
         if (useModifications) {
-            Entity entity = ((EntityLinkedItemStack) self).getEntity();
+            Entity entity = ((EntityLinkedItemStack) self).apoli$getEntity();
             if (entity instanceof LivingEntity living && ENTITY_ITEM_ENCHANTS.containsKey(living)) {
                 ConcurrentHashMap<ItemStack, NbtList> itemEnchants = ENTITY_ITEM_ENCHANTS.get(entity);
                 return EnchantmentHelper.fromNbt(itemEnchants.computeIfAbsent(self, ItemStack::getEnchantments));
@@ -165,7 +165,7 @@ public class ModifyEnchantmentLevelPower extends ValueModifyingPower {
             return 0;
         }
 
-        Entity nullsafeEntity = entity == null ? ((EntityLinkedItemStack) self).getEntity() : entity;
+        Entity nullsafeEntity = entity == null ? ((EntityLinkedItemStack) self).apoli$getEntity() : entity;
         if (nullsafeEntity instanceof LivingEntity living && ENTITY_ITEM_ENCHANTS.containsKey(living)) {
             ConcurrentHashMap<ItemStack, NbtList> itemEnchants = ENTITY_ITEM_ENCHANTS.get(living);
             Identifier id = Registries.ENCHANTMENT.getId(enchantment);

--- a/src/main/java/io/github/apace100/apoli/power/ReplaceLootTablePower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ReplaceLootTablePower.java
@@ -140,7 +140,7 @@ public class ReplaceLootTablePower extends Power {
         int count = 0;
         while(!REPLACEMENT_STACK.isEmpty()) {
             LootTable t = pop();
-            stringBuilder.append(t == null ? "null" : ((IdentifiedLootTable)t).getId());
+            stringBuilder.append(t == null ? "null" : ((IdentifiedLootTable)t).apoli$getId());
             if(!REPLACEMENT_STACK.isEmpty()) {
                 stringBuilder.append(", ");
             }
@@ -153,7 +153,7 @@ public class ReplaceLootTablePower extends Power {
         }
         while(BACKTRACK_STACK.size() > 0) {
             LootTable t = restore();
-            stringBuilder.append(t == null ? "null" : ((IdentifiedLootTable)t).getId());
+            stringBuilder.append(t == null ? "null" : ((IdentifiedLootTable)t).apoli$getId());
             if(!BACKTRACK_STACK.isEmpty()) {
                 stringBuilder.append(", ");
             }

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/ItemActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/ItemActions.java
@@ -75,7 +75,7 @@ public class ItemActions {
                     LootContextParameterSet lootContextParameterSet = new LootContextParameterSet.Builder(serverWorld).add(LootContextParameters.ORIGIN, new Vec3d(0, 0,0)).build(LootContextTypes.COMMAND);
                     LootContext lootContext = new LootContext.Builder(lootContextParameterSet).build(null);
                     ItemStack newStack = lootFunction.apply(stack, lootContext);
-                    ((MutableItemStack)stack).setFrom(newStack);
+                    ((MutableItemStack)stack).apoli$setFrom(newStack);
                 }
             }));
         register(new ActionFactory<>(Apoli.identifier("damage"), new SerializableData()

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/item/HolderAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/item/HolderAction.java
@@ -17,7 +17,7 @@ public class HolderAction {
         if(worldAndStack.getRight().isEmpty()) {
             return;
         }
-        Entity holder = ((EntityLinkedItemStack)worldAndStack.getRight()).getEntity();
+        Entity holder = ((EntityLinkedItemStack)worldAndStack.getRight()).apoli$getEntity();
         if(holder == null) {
             return;
         }

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/BiomeConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/BiomeConditions.java
@@ -8,20 +8,15 @@ import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.registry.RegistryKeys;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
-import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.biome.Biome;
 
 import java.util.List;
-import java.util.Optional;
 
 public class BiomeConditions {
 
@@ -42,7 +37,7 @@ public class BiomeConditions {
             )));
 
         register(new ConditionFactory<>(Apoli.identifier("high_humidity"), new SerializableData(),
-            (data, biome) -> ((BiomeWeatherAccess)(Object)biome.value()).getDownfall() > 0.85f));
+            (data, biome) -> ((BiomeWeatherAccess)(Object)biome.value()).apoli$getDownfall() > 0.85f));
         register(new ConditionFactory<>(Apoli.identifier("temperature"), new SerializableData()
             .add("comparison", ApoliDataTypes.COMPARISON)
             .add("compare_to", SerializableDataTypes.FLOAT),

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
@@ -17,7 +17,6 @@ import io.github.apace100.calio.data.SerializableDataTypes;
 import io.github.ladysnake.pal.PlayerAbility;
 import net.minecraft.block.pattern.CachedBlockPosition;
 import net.minecraft.enchantment.Enchantment;
-import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
@@ -35,8 +34,6 @@ import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.loot.context.LootContextTypes;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtHelper;
-import net.minecraft.scoreboard.Scoreboard;
-import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.CommandOutput;
 import net.minecraft.server.command.ServerCommandSource;
@@ -121,12 +118,12 @@ public class EntityConditions {
                 return false;
             }));
         register(new ConditionFactory<>(Apoli.identifier("submerged_in"), new SerializableData().add("fluid", SerializableDataTypes.FLUID_TAG),
-            (data, entity) -> ((SubmergableEntity)entity).isSubmergedInLoosely(data.get("fluid"))));
+            (data, entity) -> ((SubmergableEntity)entity).apoli$isSubmergedInLoosely(data.get("fluid"))));
         register(new ConditionFactory<>(Apoli.identifier("fluid_height"), new SerializableData()
             .add("fluid", SerializableDataTypes.FLUID_TAG)
             .add("comparison", ApoliDataTypes.COMPARISON)
             .add("compare_to", SerializableDataTypes.DOUBLE),
-            (data, entity) -> ((Comparison)data.get("comparison")).compare(((SubmergableEntity)entity).getFluidHeightLoosely(data.get("fluid")), data.getDouble("compare_to"))));
+            (data, entity) -> ((Comparison)data.get("comparison")).compare(((SubmergableEntity)entity).apoli$getFluidHeightLoosely(data.get("fluid")), data.getDouble("compare_to"))));
         register(PowerCondition.getFactory());
         register(new ConditionFactory<>(Apoli.identifier("food_level"), new SerializableData()
             .add("comparison", ApoliDataTypes.COMPARISON)
@@ -389,7 +386,7 @@ public class EntityConditions {
             return false;
         }));
         register(new ConditionFactory<>(Apoli.identifier("moving"), new SerializableData(),
-            (data, entity) -> ((MovingEntity)entity).isMoving()));
+            (data, entity) -> ((MovingEntity)entity).apoli$isMoving()));
         register(new ConditionFactory<>(Apoli.identifier("enchantment"), new SerializableData()
             .add("enchantment", SerializableDataTypes.ENCHANTMENT)
             .add("comparison", ApoliDataTypes.COMPARISON)

--- a/src/main/java/io/github/apace100/apoli/util/InventoryUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/InventoryUtil.java
@@ -1,6 +1,5 @@
 package io.github.apace100.apoli.util;
 
-import com.google.common.collect.Sets;
 import io.github.apace100.apoli.access.MutableItemStack;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.mixin.ItemSlotArgumentTypeAccessor;
@@ -385,7 +384,7 @@ public class InventoryUtil {
                 if (emptyStackConsumer == null) continue;
                 ItemStack newStack = getEntityLinkedEmptyStack(entity);
                 emptyStackConsumer.accept(newStack);
-                ((MutableItemStack)itemStack).setFrom(newStack);
+                ((MutableItemStack)itemStack).apoli$setFrom(newStack);
                 continue;
             }
             itemStackConsumer.accept(itemStack);

--- a/src/main/java/io/github/apace100/apoli/util/ModifiedCraftingRecipe.java
+++ b/src/main/java/io/github/apace100/apoli/util/ModifiedCraftingRecipe.java
@@ -63,7 +63,7 @@ public class ModifiedCraftingRecipe extends SpecialCraftingRecipe {
                     if (optional.isPresent())
                     {
                         ItemStack result = optional.get().getNewResult(craftingInventory, original.get());
-                        ((PowerCraftingInventory) craftingInventory).setPower(optional.get());
+                        ((PowerCraftingInventory) craftingInventory).apoli$setPower(optional.get());
                         return result;
                     }
                 }


### PR DESCRIPTION
This PR adds a prefix to all the methods and variables used by Apoli's duck interfaces in the mixin classes, which should fix #135 and possible conflicts with other mods