### PR TITLE
Fix #143

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ClientPlayerEntityMixin.java
@@ -1,5 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.mojang.authlib.GameProfile;
 import io.github.apace100.apoli.access.WaterMovingEntity;
 import io.github.apace100.apoli.component.PowerHolderComponent;
@@ -12,14 +13,11 @@ import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerAbilities;
-import net.minecraft.network.encryption.PlayerPublicKey;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -65,9 +63,9 @@ public abstract class ClientPlayerEntityMixin extends AbstractClientPlayerEntity
         return PowerHolderComponent.modify(this, ModifyAirSpeedPower.class, playerAbilities.getFlySpeed());
     }
 
-    @ModifyVariable(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isOnGround()Z", ordinal = 0), ordinal = 4)
-    private boolean modifySprintAbility(boolean original) {
-        boolean prevent = PowerHolderComponent.hasPower(this, PreventSprintingPower.class);
-        return !prevent && original;
+    @ModifyReturnValue(method = "canSprint", at = @At("RETURN"))
+    private boolean apoli$preventSprinting(boolean original) {
+        return !PowerHolderComponent.hasPower(this, PreventSprintingPower.class) && original;
     }
+
 }


### PR DESCRIPTION
This PR fixes #143 by using MixinExtras' `@ModifyReturnValue` to modify the return value of `ClientPlayerEntity#canSprint`, which is used to determine whether the player can start sprinting and/or if the player should keep sprinting