### PR TITLE
Fix #147

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/action/block/ExplodeAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/block/ExplodeAction.java
@@ -6,75 +6,47 @@ import io.github.apace100.apoli.power.factory.action.ActionFactory;
 import io.github.apace100.apoli.util.MiscUtil;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.block.pattern.CachedBlockPosition;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.fluid.FluidState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.world.BlockView;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraft.world.explosion.Explosion;
 import net.minecraft.world.explosion.ExplosionBehavior;
 import org.apache.commons.lang3.tuple.Triple;
 
-import java.util.Optional;
 import java.util.function.Predicate;
 
 public class ExplodeAction {
 
     public static void action(SerializableData.Instance data, Triple<World, BlockPos, Direction> block) {
-        if(block.getLeft().isClient) {
+
+        World world = block.getLeft();
+        if (world.isClient) {
             return;
         }
 
-        Predicate<CachedBlockPosition> indestructible = null;
-        if(data.isPresent("indestructible")) {
-            indestructible = MiscUtil.combineOr(indestructible, data.get("indestructible"));
-        }
-        if(data.isPresent("destructible")) {
+        Predicate<CachedBlockPosition> indestructibleCondition = data.get("indestructible");
+        if (data.isPresent("destructible")) {
             Predicate<CachedBlockPosition> destructibleCondition = data.get("destructible");
-            indestructible = MiscUtil.combineOr(indestructible, destructibleCondition.negate());
+            indestructibleCondition = MiscUtil.combineOr(indestructibleCondition, destructibleCondition.negate());
         }
 
-        if(indestructible != null) {
-            ExplosionBehavior eb = getExplosionBehaviour(block.getLeft(), indestructible);
-            explode(block.getLeft(), null,
-                block.getLeft().getDamageSources().explosion(null),
-                eb, block.getMiddle().getX() + 0.5, block.getMiddle().getY() + 0.5, block.getMiddle().getZ() + 0.5,
-                data.getFloat("power"), data.getBoolean("create_fire"),
-                data.get("destruction_type"));
-        } else {
-            explode(block.getLeft(),null, block.getLeft().getDamageSources().explosion(null), null,
-                    block.getMiddle().getX() + 0.5, block.getMiddle().getY() + 0.5, block.getMiddle().getZ() + 0.5,
-                    data.getFloat("power"), data.getBoolean("create_fire"),
-                    data.get("destruction_type"));
-        }
-    }
+        ExplosionBehavior behavior = MiscUtil.getExplosionBehavior(world, indestructibleCondition, true);
+        MiscUtil.createExplosion(
+            world,
+            indestructibleCondition != null ? behavior : null,
+            Vec3d.ofCenter(block.getMiddle()),
+            data.getFloat("power"),
+            data.get("create_fire"),
+            data.get("destruction_type")
+        );
 
-    private static void explode(World world, Entity entity, DamageSource damageSource, ExplosionBehavior behavior, double x, double y, double z, float power, boolean createFire, Explosion.DestructionType destructionType) {
-        Explosion explosion = new Explosion(world, entity, damageSource, behavior, x, y, z, power, createFire, destructionType);
-        explosion.collectBlocksAndDamageEntities();
-        explosion.affectWorld(true);
-    }
-
-    private static ExplosionBehavior getExplosionBehaviour(World world, Predicate<CachedBlockPosition> indestructiblePredicate) {
-        return new ExplosionBehavior() {
-            @Override
-            public Optional<Float> getBlastResistance(Explosion explosion, BlockView blockView, BlockPos pos, BlockState blockState, FluidState fluidState) {
-                CachedBlockPosition cbp = new CachedBlockPosition(world, pos, true);
-                Optional<Float> def = super.getBlastResistance(explosion, world, pos, blockState, fluidState);
-                Optional<Float> ovr = indestructiblePredicate.test(cbp) ?
-                    Optional.of(Blocks.WATER.getBlastResistance()) : Optional.empty();
-                return ovr.isPresent() ? def.isPresent() ? def.get() > ovr.get() ? def : ovr : ovr : def;
-            }
-        };
     }
 
     public static ActionFactory<Triple<World, BlockPos, Direction>> getFactory() {
-        return new ActionFactory<>(Apoli.identifier("explode"),
+        return new ActionFactory<>(
+            Apoli.identifier("explode"),
             new SerializableData()
                 .add("power", SerializableDataTypes.FLOAT)
                 .add("destruction_type", ApoliDataTypes.BACKWARDS_COMPATIBLE_DESTRUCTION_TYPE, Explosion.DestructionType.DESTROY)

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/block/ExplodeAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/block/ExplodeAction.java
@@ -12,7 +12,6 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraft.world.explosion.Explosion;
-import net.minecraft.world.explosion.ExplosionBehavior;
 import org.apache.commons.lang3.tuple.Triple;
 
 import java.util.function.Predicate;
@@ -29,17 +28,16 @@ public class ExplodeAction {
         Predicate<CachedBlockPosition> indestructibleCondition = data.get("indestructible");
         if (data.isPresent("destructible")) {
             Predicate<CachedBlockPosition> destructibleCondition = data.get("destructible");
-            indestructibleCondition = MiscUtil.combineOr(indestructibleCondition, destructibleCondition.negate());
+            indestructibleCondition = MiscUtil.combineOr(destructibleCondition.negate(), indestructibleCondition);
         }
 
-        ExplosionBehavior behavior = MiscUtil.getExplosionBehavior(world, indestructibleCondition, true);
         MiscUtil.createExplosion(
             world,
-            indestructibleCondition != null ? behavior : null,
             Vec3d.ofCenter(block.getMiddle()),
             data.getFloat("power"),
             data.get("create_fire"),
-            data.get("destruction_type")
+            data.get("destruction_type"),
+            MiscUtil.getExplosionBehavior(world, data.get("indestructible_resistance"), indestructibleCondition)
         );
 
     }
@@ -51,6 +49,7 @@ public class ExplodeAction {
                 .add("power", SerializableDataTypes.FLOAT)
                 .add("destruction_type", ApoliDataTypes.BACKWARDS_COMPATIBLE_DESTRUCTION_TYPE, Explosion.DestructionType.DESTROY)
                 .add("indestructible", ApoliDataTypes.BLOCK_CONDITION, null)
+                .add("indestructible_resistance", SerializableDataTypes.FLOAT, 5.0f)
                 .add("destructible", ApoliDataTypes.BLOCK_CONDITION, null)
                 .add("create_fire", SerializableDataTypes.BOOLEAN, false),
             ExplodeAction::action

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/block/ExplodeAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/block/ExplodeAction.java
@@ -49,7 +49,7 @@ public class ExplodeAction {
                 .add("power", SerializableDataTypes.FLOAT)
                 .add("destruction_type", ApoliDataTypes.BACKWARDS_COMPATIBLE_DESTRUCTION_TYPE, Explosion.DestructionType.DESTROY)
                 .add("indestructible", ApoliDataTypes.BLOCK_CONDITION, null)
-                .add("indestructible_resistance", SerializableDataTypes.FLOAT, 5.0f)
+                .add("indestructible_resistance", SerializableDataTypes.FLOAT, 10.0f)
                 .add("destructible", ApoliDataTypes.BLOCK_CONDITION, null)
                 .add("create_fire", SerializableDataTypes.BOOLEAN, false),
             ExplodeAction::action

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ExplodeAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ExplodeAction.java
@@ -47,7 +47,7 @@ public class ExplodeAction {
                 .add("destruction_type", ApoliDataTypes.BACKWARDS_COMPATIBLE_DESTRUCTION_TYPE, Explosion.DestructionType.DESTROY)
                 .add("damage_self", SerializableDataTypes.BOOLEAN, true)
                 .add("indestructible", ApoliDataTypes.BLOCK_CONDITION, null)
-                .add("indestructible_resistance", SerializableDataTypes.FLOAT, 5.0f)
+                .add("indestructible_resistance", SerializableDataTypes.FLOAT, 10.0f)
                 .add("destructible", ApoliDataTypes.BLOCK_CONDITION, null)
                 .add("create_fire", SerializableDataTypes.BOOLEAN, false),
             ExplodeAction::action

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ExplodeAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ExplodeAction.java
@@ -6,73 +6,44 @@ import io.github.apace100.apoli.power.factory.action.ActionFactory;
 import io.github.apace100.apoli.util.MiscUtil;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.block.pattern.CachedBlockPosition;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.damage.DamageSource;
-import net.minecraft.fluid.FluidState;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 import net.minecraft.world.explosion.Explosion;
 import net.minecraft.world.explosion.ExplosionBehavior;
 
-import java.util.Optional;
 import java.util.function.Predicate;
 
 public class ExplodeAction {
 
     public static void action(SerializableData.Instance data, Entity entity) {
-        if(entity.getWorld().isClient) {
+
+        World world = entity.getWorld();
+        if (world.isClient) {
             return;
         }
 
-        Predicate<CachedBlockPosition> indestructible = null;
-        if(data.isPresent("indestructible")) {
-            indestructible = MiscUtil.combineOr(indestructible, data.get("indestructible"));
-        }
-        if(data.isPresent("destructible")) {
+        Predicate<CachedBlockPosition> indestructibleCondition = data.get("indestructible");
+        if (data.isPresent("destructible")) {
             Predicate<CachedBlockPosition> destructibleCondition = data.get("destructible");
-            indestructible = MiscUtil.combineOr(indestructible, destructibleCondition.negate());
+            indestructibleCondition = MiscUtil.combineOr(indestructibleCondition, destructibleCondition.negate());
         }
 
-        if(indestructible != null) {
-            ExplosionBehavior eb = getExplosionBehaviour(entity.getWorld(), indestructible);
-            entity.getWorld().createExplosion(data.getBoolean("damage_self") ? null : entity,
-                null,
-                eb, entity.getX(), entity.getY(), entity.getZ(),
-                data.getFloat("power"), data.getBoolean("create_fire"),
-                data.get("destruction_type"));
-        } else {
-            explode(entity.getWorld(), data.getBoolean("damage_self") ? null : entity, null, null,
-                entity.getX(), entity.getY(), entity.getZ(),
-                data.getFloat("power"), data.getBoolean("create_fire"),
-                data.get("destruction_type"));
-        }
-    }
+        ExplosionBehavior behavior = MiscUtil.getExplosionBehavior(world, indestructibleCondition, true);
+        MiscUtil.createExplosion(
+            world,
+            entity,
+            indestructibleCondition != null ? behavior : null,
+            entity.getPos(),
+            data.getFloat("power"),
+            data.getBoolean("create_fire"),
+            data.get("destruction_type")
+        );
 
-    private static void explode(World world, Entity entity, DamageSource damageSource, ExplosionBehavior behavior, double x, double y, double z, float power, boolean createFire, Explosion.DestructionType destructionType) {
-        Explosion explosion = new Explosion(world, entity, damageSource, behavior, x, y, z, power, createFire, destructionType);
-        explosion.collectBlocksAndDamageEntities();
-        explosion.affectWorld(true);
     }
-
-    private static ExplosionBehavior getExplosionBehaviour(World world, Predicate<CachedBlockPosition> indestructiblePredicate) {
-        return new ExplosionBehavior() {
-            @Override
-            public Optional<Float> getBlastResistance(Explosion explosion, BlockView blockView, BlockPos pos, BlockState blockState, FluidState fluidState) {
-                CachedBlockPosition cbp = new CachedBlockPosition(world, pos, true);
-                Optional<Float> def = super.getBlastResistance(explosion, world, pos, blockState, fluidState);
-                Optional<Float> ovr = indestructiblePredicate.test(cbp) ?
-                    Optional.of(Blocks.WATER.getBlastResistance()) : Optional.empty();
-                return ovr.isPresent() ? def.isPresent() ? def.get() > ovr.get() ? def : ovr : ovr : def;
-            }
-        };
-    }
-
     public static ActionFactory<Entity> getFactory() {
-        return new ActionFactory<>(Apoli.identifier("explode"),
+        return new ActionFactory<>(
+            Apoli.identifier("explode"),
             new SerializableData()
                 .add("power", SerializableDataTypes.FLOAT)
                 .add("destruction_type", ApoliDataTypes.BACKWARDS_COMPATIBLE_DESTRUCTION_TYPE, Explosion.DestructionType.DESTROY)

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ExplodeAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/entity/ExplodeAction.java
@@ -10,7 +10,6 @@ import net.minecraft.block.pattern.CachedBlockPosition;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
 import net.minecraft.world.explosion.Explosion;
-import net.minecraft.world.explosion.ExplosionBehavior;
 
 import java.util.function.Predicate;
 
@@ -26,18 +25,17 @@ public class ExplodeAction {
         Predicate<CachedBlockPosition> indestructibleCondition = data.get("indestructible");
         if (data.isPresent("destructible")) {
             Predicate<CachedBlockPosition> destructibleCondition = data.get("destructible");
-            indestructibleCondition = MiscUtil.combineOr(indestructibleCondition, destructibleCondition.negate());
+            indestructibleCondition = MiscUtil.combineOr(destructibleCondition.negate(), indestructibleCondition);
         }
 
-        ExplosionBehavior behavior = MiscUtil.getExplosionBehavior(world, indestructibleCondition, true);
         MiscUtil.createExplosion(
             world,
             entity,
-            indestructibleCondition != null ? behavior : null,
             entity.getPos(),
             data.getFloat("power"),
             data.getBoolean("create_fire"),
-            data.get("destruction_type")
+            data.get("destruction_type"),
+            MiscUtil.getExplosionBehavior(world, data.get("indestructible_resistance"), indestructibleCondition)
         );
 
     }
@@ -49,6 +47,7 @@ public class ExplodeAction {
                 .add("destruction_type", ApoliDataTypes.BACKWARDS_COMPATIBLE_DESTRUCTION_TYPE, Explosion.DestructionType.DESTROY)
                 .add("damage_self", SerializableDataTypes.BOOLEAN, true)
                 .add("indestructible", ApoliDataTypes.BLOCK_CONDITION, null)
+                .add("indestructible_resistance", SerializableDataTypes.FLOAT, 5.0f)
                 .add("destructible", ApoliDataTypes.BLOCK_CONDITION, null)
                 .add("create_fire", SerializableDataTypes.BOOLEAN, false),
             ExplodeAction::action

--- a/src/main/java/io/github/apace100/apoli/util/MiscUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/MiscUtil.java
@@ -81,6 +81,11 @@ public final class MiscUtil {
 
             }
 
+            @Override
+            public boolean canDestroyBlock(Explosion explosion, BlockView blockView, BlockPos pos, BlockState state, float power) {
+                return !indestructibleCondition.test(new CachedBlockPosition(world, pos, true));
+            }
+
         };
     }
 

--- a/src/main/java/io/github/apace100/apoli/util/MiscUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/MiscUtil.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonSyntaxException;
 import io.github.apace100.apoli.data.DamageSourceDescription;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.pattern.CachedBlockPosition;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -13,18 +14,66 @@ import net.minecraft.entity.damage.DamageSources;
 import net.minecraft.entity.damage.DamageType;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.packet.s2c.play.ExplosionS2CPacket;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
+import net.minecraft.world.explosion.Explosion;
+import net.minecraft.world.explosion.ExplosionBehavior;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.function.Predicate;
 
 public final class MiscUtil {
+
+    public static void createExplosion(World world, ExplosionBehavior behavior, Vec3d pos, float power, boolean createFire, Explosion.DestructionType destructionType) {
+        createExplosion(world, null, behavior, pos, power, createFire, destructionType);
+    }
+
+    public static void createExplosion(World world, Entity entity, ExplosionBehavior behavior, Vec3d pos, float power, boolean createFire, Explosion.DestructionType destructionType) {
+        createExplosion(world, entity, world.getDamageSources().explosion(null), behavior, pos.getX(), pos.getY(), pos.getZ(), power, createFire, destructionType);
+    }
+
+    public static void createExplosion(World world, Entity entity, DamageSource damageSource, ExplosionBehavior behavior, double x, double y, double z, float power, boolean createFire, Explosion.DestructionType destructionType) {
+
+        Explosion explosion = new Explosion(world, entity, damageSource, behavior, x, y, z, power, createFire, destructionType);
+
+        explosion.collectBlocksAndDamageEntities();
+        explosion.affectWorld(true);
+
+        //  Sync the explosion effect to the client if the explosion is created on the server
+        if (!(world instanceof ServerWorld serverWorld)) {
+            return;
+        }
+
+        if (!explosion.shouldDestroy()) {
+            explosion.clearAffectedBlocks();
+        }
+
+        for (ServerPlayerEntity serverPlayerEntity : serverWorld.getPlayers()) {
+            if (serverPlayerEntity.squaredDistanceTo(x, y, z) < 4096.0) {
+                serverPlayerEntity.networkHandler.sendPacket(new ExplosionS2CPacket(x, y, z, power, explosion.getAffectedBlocks(), explosion.getAffectedPlayers().get(serverPlayerEntity)));
+            }
+        }
+
+    }
+
+    public static ExplosionBehavior getExplosionBehavior(World world, Predicate<CachedBlockPosition> blockCondition, boolean invert) {
+        return new ExplosionBehavior() {
+
+            @Override
+            public boolean canDestroyBlock(Explosion explosion, BlockView blockView, BlockPos pos, BlockState state, float power) {
+                return invert != blockCondition.test(new CachedBlockPosition(world, pos, true));
+            }
+
+        };
+    }
 
     public static Optional<Entity> getEntityWithPassengers(World world, EntityType<?> entityType, @Nullable NbtCompound entityNbt, Vec3d pos, float yaw, float pitch) {
 


### PR DESCRIPTION
This PR fixes #147 and simplifies how explosions are created in the `explode` entity/block action types by generalizing the methods for creating explosions in a utility class. This also implements how vanilla syncs the explosions created on the server-side, so the explosion particle and sound effects are emitted