### PR TITLE
Change how `prevent_item_use` displays its usability hint

### DIFF
--- a/src/main/java/io/github/apace100/apoli/ApoliClient.java
+++ b/src/main/java/io/github/apace100/apoli/ApoliClient.java
@@ -33,7 +33,7 @@ import java.util.List;
 @Environment(EnvType.CLIENT)
 public class ApoliClient implements ClientModInitializer {
 
-	public static KeyBinding showPreventingPowers;
+	public static KeyBinding showPowersOnUsabilityHint;
 
 	public static boolean shouldReloadWorldRenderer = false;
 
@@ -48,8 +48,8 @@ public class ApoliClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 
-		showPreventingPowers = new KeyBinding("key.apoli.use_preventing_powers.show", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_LEFT_ALT, "category." + Apoli.MODID);
-		KeyBindingHelper.registerKeyBinding(showPreventingPowers);
+		showPowersOnUsabilityHint = new KeyBinding("key.apoli.usability_hint.show_powers", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_LEFT_ALT, "category." + Apoli.MODID);
+		KeyBindingHelper.registerKeyBinding(showPowersOnUsabilityHint);
 
 		ModPacketsS2C.register();
 

--- a/src/main/java/io/github/apace100/apoli/ApoliClient.java
+++ b/src/main/java/io/github/apace100/apoli/ApoliClient.java
@@ -18,10 +18,13 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.network.PacketByteBuf;
+import org.lwjgl.glfw.GLFW;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -29,6 +32,8 @@ import java.util.List;
 
 @Environment(EnvType.CLIENT)
 public class ApoliClient implements ClientModInitializer {
+
+	public static KeyBinding showPreventingPowers;
 
 	public static boolean shouldReloadWorldRenderer = false;
 
@@ -42,6 +47,9 @@ public class ApoliClient implements ClientModInitializer {
 
 	@Override
 	public void onInitializeClient() {
+
+		showPreventingPowers = new KeyBinding("key.apoli.use_preventing_powers.show", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_LEFT_ALT, "category." + Apoli.MODID);
+		KeyBindingHelper.registerKeyBinding(showPreventingPowers);
 
 		ModPacketsS2C.register();
 

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixinClient.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixinClient.java
@@ -93,7 +93,7 @@ public abstract class ItemStackMixinClient {
             } else {
 
                 MinecraftClient client = MinecraftClient.getInstance();
-                KeyBinding keyBinding = ApoliClient.showPreventingPowers;
+                KeyBinding keyBinding = ApoliClient.showPowersOnUsabilityHint;
 
                 Integer keyCode = keyBinding.isUnbound() ? null : InputUtil.fromTranslationKey(keyBinding.getBoundKeyTranslationKey()).getCode();
                 boolean isKeyPressed = keyCode != null && InputUtil.isKeyPressed(client.getWindow().getHandle(), keyCode);
@@ -102,7 +102,7 @@ public abstract class ItemStackMixinClient {
                     apoli$addExpandedTooltip(powers, tooltip, translationKey, powerTextColor, baseTextColor);
                 } else {
 
-                    powerText = Text.translatable("tooltip.apoli.use_preventing_powers.count", powers.size()).formatted(powerTextColor);
+                    powerText = Text.translatable("tooltip.apoli.usability_hint.power_count", powers.size()).formatted(powerTextColor);
                     baseText = Text.translatable(translationKey, powerText).formatted(baseTextColor);
 
                     tooltip.add(baseText);
@@ -113,7 +113,7 @@ public abstract class ItemStackMixinClient {
                         .withItalic(keyBinding.isUnbound())
                     );
 
-                    Text guideText = Text.translatable("tooltip.apoli.use_preventing_powers.show", keybindText).formatted(baseTextColor);
+                    Text guideText = Text.translatable("tooltip.apoli.usability_hint.show_powers", keybindText).formatted(baseTextColor);
                     tooltip.add(guideText);
 
                 }
@@ -189,7 +189,7 @@ public abstract class ItemStackMixinClient {
 
         }
 
-        Text powerText = Text.translatable("tooltip.apoli.use_preventing_powers.count", powers.size()).formatted(powerTextColor);
+        Text powerText = Text.translatable("tooltip.apoli.usability_hint.power_count", powers.size()).formatted(powerTextColor);
         Text baseText = Text.translatable(translationKey, powerText).formatted(baseTextColor);
 
         tooltip.add(baseText);

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixinClient.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixinClient.java
@@ -1,17 +1,22 @@
 package io.github.apace100.apoli.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import io.github.apace100.apoli.Apoli;
-import io.github.apace100.apoli.access.MutableItemStack;
+import io.github.apace100.apoli.ApoliClient;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.PowerType;
 import io.github.apace100.apoli.power.PowerTypeRegistry;
 import io.github.apace100.apoli.power.PreventItemUsePower;
 import io.github.apace100.apoli.power.TooltipPower;
 import io.github.apace100.apoli.util.ApoliConfigClient;
+import io.github.apace100.apoli.util.KeyBindingUtil;
 import io.github.apace100.apoli.util.StackPowerUtil;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.item.TooltipContext;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -22,12 +27,13 @@ import net.minecraft.util.UseAction;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
@@ -45,78 +51,150 @@ public abstract class ItemStackMixinClient {
         return (flags & tooltipSection.getFlag()) == 0;
     }
 
-    @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0, shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void addUnusableTooltip(@Nullable PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir, List<Text> list) {
-        if(player != null) {
-            ApoliConfigClient.Tooltips config = ((ApoliConfigClient) Apoli.config).tooltips;
-            if(!config.showUsabilityHints || !isSectionVisible(getHideFlags(), ItemStack.TooltipSection.ADDITIONAL)) {
-                return;
-            }
-            List<PreventItemUsePower> powers = PowerHolderComponent.getPowers(player, PreventItemUsePower.class).stream().filter(p -> p.doesPrevent((ItemStack)(Object)this)).toList();
-            int powerCountWithHidden = powers.size();
-            powers = powers.stream().filter(p -> !p.getType().isHidden()).toList();
-            if(powerCountWithHidden == 0) {
-                return;
-            }
-            String translationKeyBase = "tooltip.apoli.unusable." + getUseAction().name().toLowerCase(Locale.ROOT);
-            Formatting textColor = Formatting.GRAY;
-            Formatting powerColor = Formatting.RED;
-            if(config.compactUsabilityHints || powers.size() == 0) {
-                if(powers.size() == 1) {
-                    PreventItemUsePower power = powers.get(0);
-                    MutableText preventText = Text.translatable(translationKeyBase + ".single",
-                            power.getType().getName().formatted(powerColor)).formatted(textColor);
-                    list.add(preventText);
-                } else {
-                    list.add(
-                            Text.translatable(translationKeyBase + ".multiple",
-                                            Text.literal((powers.size() == 0 ? powerCountWithHidden : powers.size()) + "").formatted(powerColor))
-                                    .formatted(textColor));
-                }
+    @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0, shift = At.Shift.AFTER))
+    private void apoli$addUnusableTooltip(@Nullable PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir, @Local List<Text> tooltip) {
+
+        if (player == null) {
+            return;
+        }
+
+        ApoliConfigClient.Tooltips config = ((ApoliConfigClient) Apoli.config).tooltips;
+        if (!config.showUsabilityHints || !isSectionVisible(getHideFlags(), ItemStack.TooltipSection.ADDITIONAL)) {
+            return;
+        }
+
+        List<PreventItemUsePower> powers = PowerHolderComponent.getPowers(player, PreventItemUsePower.class)
+            .stream()
+            .filter(p -> p.doesPrevent((ItemStack) (Object) this))
+            .toList();
+        if (powers.isEmpty()) {
+            return;
+        }
+
+        String translationKey = "tooltip.apoli.unusable." + getUseAction().toString().toLowerCase(Locale.ROOT) + (powers.size() == 1 ? ".single" : ".multiple");
+
+        Formatting baseTextColor = Formatting.GRAY;
+        Formatting powerTextColor = Formatting.RED;
+
+        Text baseText;
+        Text powerText;
+
+        if (config.compactUsabilityHints || powers.size() == 1) {
+
+            if (powers.size() == 1) {
+
+                PreventItemUsePower power = powers.get(0);
+
+                powerText = power.getType().getName().formatted(powerTextColor);
+                baseText = Text.translatable(translationKey, powerText).formatted(baseTextColor);
+
+                tooltip.add(baseText);
+
             } else {
-                MutableText powerNameList = powers.get(0).getType().getName().formatted(powerColor);
-                for(int i = 1; i < powers.size(); i++) {
-                    powerNameList = powerNameList.append(Text.literal(", ").formatted(textColor));
-                    powerNameList = powerNameList.append(powers.get(i).getType().getName().formatted(powerColor));
+
+                MinecraftClient client = MinecraftClient.getInstance();
+                KeyBinding keyBinding = ApoliClient.showPreventingPowers;
+
+                Integer keyCode = keyBinding.isUnbound() ? null : InputUtil.fromTranslationKey(keyBinding.getBoundKeyTranslationKey()).getCode();
+                boolean isKeyPressed = keyCode != null && InputUtil.isKeyPressed(client.getWindow().getHandle(), keyCode);
+
+                if (isKeyPressed) {
+                    apoli$addExpandedTooltip(powers, tooltip, translationKey, powerTextColor, baseTextColor);
+                } else {
+
+                    powerText = Text.translatable("tooltip.apoli.use_preventing_powers.count", powers.size()).formatted(powerTextColor);
+                    baseText = Text.translatable(translationKey, powerText).formatted(baseTextColor);
+
+                    tooltip.add(baseText);
+                    tooltip.add(Text.empty());
+
+                    Text keybindText = KeyBindingUtil.getLocalizedName(keyBinding.getTranslationKey()).styled(style -> style
+                        .withColor(Formatting.YELLOW)
+                        .withItalic(keyBinding.isUnbound())
+                    );
+
+                    Text guideText = Text.translatable("tooltip.apoli.use_preventing_powers.show", keybindText).formatted(baseTextColor);
+                    tooltip.add(guideText);
+
                 }
-                MutableText preventText = Text.translatable(translationKeyBase + ".single",
-                        powerNameList).formatted(textColor);
-                list.add(preventText);
+
             }
+        } else {
+            apoli$addExpandedTooltip(powers, tooltip, translationKey, powerTextColor, baseTextColor);
         }
+
     }
 
-    @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;hasNbt()Z", ordinal = 1), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void addEquipmentPowerTooltips(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir, List<Text> list) {
-        for(EquipmentSlot slot : EquipmentSlot.values()) {
-            List<StackPowerUtil.StackPower> powers = StackPowerUtil.getPowers((ItemStack)(Object)this, slot)
-                    .stream()
-                    .filter(sp -> !sp.isHidden)
-                    .toList();
-            if(powers.size() > 0) {
-                list.add(Text.empty());
-                list.add((Text.translatable("item.modifiers." + slot.getName())).formatted(Formatting.GRAY));
-                powers.forEach(sp -> {
+    @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;hasNbt()Z", ordinal = 1))
+    private void apoli$addStackPowerTooltips(@Nullable PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir, @Local List<Text> texts) {
 
-                    if(PowerTypeRegistry.contains(sp.powerId)) {
-                        PowerType<?> powerType = PowerTypeRegistry.get(sp.powerId);
-                        list.add(
-                                Text.literal(" ")
-                                        .append(powerType.getName())
-                                        .formatted(sp.isNegative ? Formatting.RED : Formatting.BLUE));
-                        if(context.isAdvanced()) {
-                            list.add(
-                                    Text.literal("  ")
-                                            .append(powerType.getDescription())
-                                            .formatted(Formatting.GRAY));
-                        }
-                    }
-                });
+        for (EquipmentSlot slot : EquipmentSlot.values()) {
+
+            List<StackPowerUtil.StackPower> stackPowers = StackPowerUtil.getPowers((ItemStack) (Object) this, slot)
+                .stream()
+                .filter(sp -> !sp.isHidden)
+                .toList();
+            if (stackPowers.isEmpty()) {
+                continue;
             }
+
+            texts.add(Text.empty());
+            texts.add(Text.translatable("item.modifiers." + slot.getName()).formatted(Formatting.GRAY));
+
+            for (StackPowerUtil.StackPower stackPower : stackPowers) {
+
+                if (!PowerTypeRegistry.contains(stackPower.powerId)) {
+                    continue;
+                }
+
+                PowerType<?> powerType = PowerTypeRegistry.get(stackPower.powerId);
+                Text powerNameText = Text
+                    .literal(" ")
+                    .append(powerType.getName())
+                    .formatted(stackPower.isNegative ? Formatting.RED : Formatting.BLUE);
+                texts.add(powerNameText);
+
+                if (!context.isAdvanced()) {
+                    continue;
+                }
+
+                Text powerDescriptionText = Text
+                    .literal("  ")
+                    .append(powerType.getDescription())
+                    .formatted(Formatting.GRAY);
+                texts.add(powerDescriptionText);
+
+            }
+
         }
+
         PowerHolderComponent.getPowers(player, TooltipPower.class)
-                .stream().filter(t -> t.doesApply((ItemStack) (Object)this))
-                .sorted(Comparator.comparing(TooltipPower::getOrder))
-                .forEachOrdered(t -> t.addToTooltip(list));
+            .stream()
+            .filter(p -> p.doesApply((ItemStack) (Object) this))
+            .sorted(Comparator.comparing(TooltipPower::getOrder))
+            .forEachOrdered(p -> p.addToTooltip(texts));
+
     }
+
+    @Unique
+    private void apoli$addExpandedTooltip(List<PreventItemUsePower> powers, List<Text> tooltip, String translationKey, Formatting powerTextColor, Formatting baseTextColor) {
+
+        List<Text> powerTexts = new LinkedList<>();
+        for (PreventItemUsePower power : powers) {
+
+            MutableText prependedText = Text.literal("  - ").formatted(baseTextColor);
+            MutableText powerText = power.getType().getName().formatted(powerTextColor);
+
+            powerTexts.add(prependedText.append(powerText));
+
+        }
+
+        Text powerText = Text.translatable("tooltip.apoli.use_preventing_powers.count", powers.size()).formatted(powerTextColor);
+        Text baseText = Text.translatable(translationKey, powerText).formatted(baseTextColor);
+
+        tooltip.add(baseText);
+        tooltip.addAll(powerTexts);
+
+    }
+
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/KeyBindingAccessor.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/KeyBindingAccessor.java
@@ -1,0 +1,17 @@
+package io.github.apace100.apoli.mixin;
+
+import net.minecraft.client.option.KeyBinding;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+
+@Mixin(KeyBinding.class)
+public interface KeyBindingAccessor {
+
+    @Accessor("KEYS_BY_ID")
+    static Map<String, KeyBinding> getKeysById() {
+        throw new AssertionError();
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/util/ApoliConfigClient.java
+++ b/src/main/java/io/github/apace100/apoli/util/ApoliConfigClient.java
@@ -21,6 +21,6 @@ public class ApoliConfigClient extends ApoliConfig {
     public static class Tooltips {
 
         public boolean showUsabilityHints = true;
-        public boolean compactUsabilityHints = false;
+        public boolean compactUsabilityHints = true;
     }
 }

--- a/src/main/java/io/github/apace100/apoli/util/KeyBindingUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/KeyBindingUtil.java
@@ -1,0 +1,32 @@
+package io.github.apace100.apoli.util;
+
+import io.github.apace100.apoli.mixin.KeyBindingAccessor;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+
+@Environment(EnvType.CLIENT)
+public class KeyBindingUtil {
+
+    /**
+     *  Get the localized name of the keybind from the specified ID. If no such keybind exists or if the keybind is
+     *  not bound to any key, use the specified ID instead.
+     *
+     *  @param translationKey   The translation key of the keybind to get its localized bound key name of.
+     *  @return                 Either a {@linkplain Text text} that is localized, or a {@linkplain net.minecraft.text.TranslatableTextContent translatable text}
+     *                              that contains the specified translation key.
+     */
+    public static MutableText getLocalizedName(String translationKey) {
+
+        KeyBinding keyBinding = KeyBindingAccessor.getKeysById().get(translationKey);
+        if (keyBinding == null || keyBinding.isUnbound()) {
+            return Text.translatable(translationKey);
+        }
+
+        return keyBinding.getBoundKeyLocalizedText().copy();
+
+    }
+
+}

--- a/src/main/resources/apoli.mixins.json
+++ b/src/main/resources/apoli.mixins.json
@@ -72,6 +72,7 @@
 		"InGameHudMixin",
 		"InGameOverlayRendererMixin",
 		"ItemStackMixinClient",
+		"KeyBindingAccessor",
 		"LightmapTextureManagerMixin",
 		"LivingEntityRendererMixin",
 		"MinecraftClientMixin",

--- a/src/main/resources/assets/apoli/lang/en_us.json
+++ b/src/main/resources/assets/apoli/lang/en_us.json
@@ -1,73 +1,51 @@
 {
-
 	"argument.apoli.power_holder.not_found.multiple": "No living entities were found",
 	"argument.apoli.power_holder.not_found.single": "Entity %s is not a living entity",
-
+	"category.apoli": "Apoli",
 	"commands.apoli.clear.fail.multiple": "No entity had any power to clear.",
 	"commands.apoli.clear.fail.single": "Entity %s did not have any power to clear.",
-
 	"commands.apoli.clear.success.multiple": "%s entities had in total %s powers cleared.",
 	"commands.apoli.clear.success.single": "Entity %s had %s powers cleared.",
-
 	"commands.apoli.grant.fail.multiple": "All %s entities already had the power %s from source %s.",
 	"commands.apoli.grant.fail.single": "Entity %s already had the power %s from source %s.",
-
 	"commands.apoli.grant.success.multiple": "%s entities were granted the power %s.",
 	"commands.apoli.grant.success.single": "Entity %s was granted the power %s.",
-
 	"commands.apoli.grant_from_source.success.multiple": "%s entities were granted the power %s from source %s.",
 	"commands.apoli.grant_from_source.success.single": "Entity %s was granted the power %s from source %s.",
-
 	"commands.apoli.list.fail": "Entity %s did not have any powers.",
 	"commands.apoli.list.pass": "Entity %s has %s powers: [%s]",
 	"commands.apoli.list.sources": "Sources: [%s]",
-
 	"commands.apoli.power_not_found": "Unknown power: %s",
-
 	"commands.apoli.remove.fail.multiple": "No entity had the power %s.",
 	"commands.apoli.remove.fail.single": "Entity %s did not have the power %s.",
-
 	"commands.apoli.remove.success.multiple": "%s entities had the power %s removed.",
 	"commands.apoli.remove.success.single": "Entity %s had the power %s removed.",
-
 	"commands.apoli.revoke.fail.multiple": "No entity had the power %s from source %s.",
 	"commands.apoli.revoke.fail.single": "Entity %s did not have the power %s from source %s.",
-
 	"commands.apoli.revoke.success.multiple": "%s entities had the power %s revoked.",
 	"commands.apoli.revoke.success.single": "Entity %s had the power %s revoked.",
-
 	"commands.apoli.revoke_all.fail.multiple": "No entity had any power from source %s.",
 	"commands.apoli.revoke_all.fail.single": "Entity %s did not have any power from source %s.",
-
 	"commands.apoli.revoke_all.success.multiple": "%s entities had %s powers revoked from source %s.",
 	"commands.apoli.revoke_all.success.single": "Entity %s had %s powers revoked from source %s.",
-
 	"commands.apoli.revoke_from_source.success.multiple": "%s entities had the power %s revoked from source %s.",
 	"commands.apoli.revoke_from_source.success.single": "Entity %s had the power %s revoked from source %s.",
-
 	"commands.apoli.sources.fail": "Entity %s did not have the power %s.",
 	"commands.apoli.sources.pass": "Entity %s has %s sources of power %s: [%s]",
-
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-
+	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
 	"text.apoli.cannot_sleep": "You cannot sleep",
-
 	"text.autoconfig.power_config.option.executeCommand": "Execute Command",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Permission Level",
 	"text.autoconfig.power_config.option.executeCommand.showOutput": "Show Output in Chat",
-
 	"text.autoconfig.power_config.option.resourcesAndCooldowns": "Resources & Cooldowns",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetX": "HUD Offset X",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetY": "HUD Offset Y",
-
 	"text.autoconfig.power_config.option.tooltips": "Tooltips",
-
 	"text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compact Usability Hints",
 	"text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Show Usability Hints",
-
 	"text.autoconfig.power_config.title": "Apoli Power Config",
-
 	"tooltip.apoli.unusable.block.multiple": "Unusable (%s)",
 	"tooltip.apoli.unusable.block.single": "Unusable (%s)",
 	"tooltip.apoli.unusable.bow.multiple": "Unusable (%s)",
@@ -85,6 +63,7 @@
 	"tooltip.apoli.unusable.spyglass.multiple": "Unusable (%s)",
 	"tooltip.apoli.unusable.spyglass.single": "Unusable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
-	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)"
-
+	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
+	"tooltip.apoli.use_preventing_powers.count": "%s powers",
+	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/en_us.json
+++ b/src/main/resources/assets/apoli/lang/en_us.json
@@ -34,7 +34,7 @@
 	"commands.apoli.sources.pass": "Entity %s has %s sources of power %s: [%s]",
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
+	"key.apoli.usability_hint.show_powers": "Show Powers in Usability Hints",
 	"text.apoli.cannot_sleep": "You cannot sleep",
 	"text.autoconfig.power_config.option.executeCommand": "Execute Command",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Permission Level",
@@ -64,6 +64,6 @@
 	"tooltip.apoli.unusable.spyglass.single": "Unusable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
 	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
-	"tooltip.apoli.use_preventing_powers.count": "%s powers",
-	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
+	"tooltip.apoli.usability_hint.power_count": "%s powers",
+	"tooltip.apoli.usability_hint.show_powers": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_ar.json
+++ b/src/main/resources/assets/apoli/lang/es_ar.json
@@ -1,72 +1,51 @@
 {
-
 	"argument.apoli.power_holder.not_found.multiple": "No living entities were found",
 	"argument.apoli.power_holder.not_found.single": "Entity %s is not a living entity",
-
+	"category.apoli": "Apoli",
 	"commands.apoli.clear.fail.multiple": "Ninguna de las entidades seleccionadas tenía poderes que eliminar.",
 	"commands.apoli.clear.fail.single": "La entidad %s no tenía ningún poder que eliminar.",
-
 	"commands.apoli.clear.success.multiple": "Se le han eliminado %2$s poderes a %1$s entidades.",
 	"commands.apoli.clear.success.single": "Se le han eliminado %2$s poderes a la entidad %1$s.",
-
 	"commands.apoli.grant.fail.multiple": "Todas las %s entidades ya tenían el poder %s de la fuente %s.",
 	"commands.apoli.grant.fail.single": "La entidad %s ya tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.grant.success.multiple": "Se le ha dado el poder %2$s a %1$s entidades.",
 	"commands.apoli.grant.success.single": "Se le ha dado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.grant_from_source.success.multiple": "Se le ha dado el poder %2$s de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.grant_from_source.success.single": "Se le ha dado el poder %2$s de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.list.fail": "La entidad seleccionada no está viva, así que no puede tener poderes.",
 	"commands.apoli.list.pass": "La entidad tiene %s poderes: [%s]",
-
 	"commands.apoli.list.sources": "Sources: [%s]",
 	"commands.apoli.power_not_found": "Unknown power: %s",
-
 	"commands.apoli.remove.fail.multiple": "Ninguna de las entidades tenía el poder %s.",
 	"commands.apoli.remove.fail.single": "La entidad %s no tenía el poder %s.",
-
 	"commands.apoli.remove.success.multiple": "Se le ha removido el poder %2$s a %1$s entidades.",
 	"commands.apoli.remove.success.single": "Se le ha removido el poder %2$s a la entidad %1$s",
-
 	"commands.apoli.revoke.fail.multiple": "Ninguna de las entidades seleccionadas tenía el poder %s de la fuente %s.",
 	"commands.apoli.revoke.fail.single": "La entidad %s no tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.revoke.success.multiple": "Se le ha revocado el poder %2$s a %1$s entidades.",
 	"commands.apoli.revoke.success.single": "Se le ha revocado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_all.fail.multiple": "Ninguna de las entidades seleccionadas tenía algún poder de la fuente %s.",
 	"commands.apoli.revoke_all.fail.single": "La entidad %s no tenía ningún poder de la fuente %s.",
-
 	"commands.apoli.revoke_all.success.multiple": "Se le han revocado %2$s poderes de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.revoke_all.success.single": "Se le han revocado %2$s poderes de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_from_source.success.multiple": "Se le ha revocado el poder %2$s de la fuente %2$s a %1$s entidades.",
 	"commands.apoli.revoke_from_source.success.single": "Se le ha revocado el poder %2$s de la fuente %2$s a la entidad %1$s.",
-
 	"commands.apoli.sources.fail": "La entidad %s es inerte o no tiene el poder %s.",
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
-
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-
+	"key.apoli.use_preventing_powers.show": "Show use-preventing powers",
 	"text.apoli.cannot_sleep": "You cannot sleep",
-
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
 	"text.autoconfig.power_config.option.executeCommand.showOutput": "Notificar ejecución de comandos en el chat",
-
 	"text.autoconfig.power_config.option.resourcesAndCooldowns": "Recursos y Cooldowns",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetX": "HUD Offset X",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetY": "HUD Offset Y",
-
 	"text.autoconfig.power_config.option.tooltips": "Descripción de Objetos",
 	"text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compactar descripción de Usabilidad",
 	"text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Mostrar Usabilidad",
-
 	"text.autoconfig.power_config.title": "Configuración de Apoli",
-
 	"tooltip.apoli.unusable.block.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.block.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.bow.multiple": "Inutilizable (%s)",
@@ -84,6 +63,7 @@
 	"tooltip.apoli.unusable.spyglass.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
-	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)"
-
+	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
+	"tooltip.apoli.use_preventing_powers.count": "%s powers",
+	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_ar.json
+++ b/src/main/resources/assets/apoli/lang/es_ar.json
@@ -34,7 +34,7 @@
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-	"key.apoli.use_preventing_powers.show": "Show use-preventing powers",
+	"key.apoli.usability_hint.show_powers": "Show Powers in Usability Hints",
 	"text.apoli.cannot_sleep": "You cannot sleep",
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
@@ -64,6 +64,6 @@
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
 	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
-	"tooltip.apoli.use_preventing_powers.count": "%s powers",
-	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
+	"tooltip.apoli.usability_hint.power_count": "%s powers",
+	"tooltip.apoli.usability_hint.show_powers": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_cl.json
+++ b/src/main/resources/assets/apoli/lang/es_cl.json
@@ -34,7 +34,7 @@
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
+	"key.apoli.usability_hint.show_powers": "Show Powers in Usability Hints",
 	"text.apoli.cannot_sleep": "You cannot sleep",
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
@@ -64,6 +64,6 @@
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
 	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
-	"tooltip.apoli.use_preventing_powers.count": "%s powers",
-	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
+	"tooltip.apoli.usability_hint.power_count": "%s powers",
+	"tooltip.apoli.usability_hint.show_powers": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_cl.json
+++ b/src/main/resources/assets/apoli/lang/es_cl.json
@@ -1,72 +1,51 @@
 {
-
 	"argument.apoli.power_holder.not_found.multiple": "No living entities were found",
 	"argument.apoli.power_holder.not_found.single": "Entity %s is not a living entity",
-
+	"category.apoli": "Apoli",
 	"commands.apoli.clear.fail.multiple": "Ninguna de las entidades seleccionadas tenía poderes que eliminar.",
 	"commands.apoli.clear.fail.single": "La entidad %s no tenía ningún poder que eliminar.",
-
 	"commands.apoli.clear.success.multiple": "Se le han eliminado %2$s poderes a %1$s entidades.",
 	"commands.apoli.clear.success.single": "Se le han eliminado %2$s poderes a la entidad %1$s.",
-
 	"commands.apoli.grant.fail.multiple": "Todas las %s entidades ya tenían el poder %s de la fuente %s.",
 	"commands.apoli.grant.fail.single": "La entidad %s ya tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.grant.success.multiple": "Se le ha dado el poder %2$s a %1$s entidades.",
 	"commands.apoli.grant.success.single": "Se le ha dado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.grant_from_source.success.multiple": "Se le ha dado el poder %2$s de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.grant_from_source.success.single": "Se le ha dado el poder %2$s de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.list.fail": "La entidad seleccionada no está viva, así que no puede tener poderes.",
 	"commands.apoli.list.pass": "La entidad tiene %s poderes: [%s]",
-
 	"commands.apoli.list.sources": "Sources: [%s]",
 	"commands.apoli.power_not_found": "Unknown power: %s",
-
 	"commands.apoli.remove.fail.multiple": "Ninguna de las entidades tenía el poder %s.",
 	"commands.apoli.remove.fail.single": "La entidad %s no tenía el poder %s.",
-
 	"commands.apoli.remove.success.multiple": "Se le ha removido el poder %2$s a %1$s entidades.",
 	"commands.apoli.remove.success.single": "Se le ha removido el poder %2$s a la entidad %1$s",
-
 	"commands.apoli.revoke.fail.multiple": "Ninguna de las entidades seleccionadas tenía el poder %s de la fuente %s.",
 	"commands.apoli.revoke.fail.single": "La entidad %s no tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.revoke.success.multiple": "Se le ha revocado el poder %2$s a %1$s entidades.",
 	"commands.apoli.revoke.success.single": "Se le ha revocado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_all.fail.multiple": "Ninguna de las entidades seleccionadas tenía algún poder de la fuente %s.",
 	"commands.apoli.revoke_all.fail.single": "La entidad %s no tenía ningún poder de la fuente %s.",
-
 	"commands.apoli.revoke_all.success.multiple": "Se le han revocado %2$s poderes de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.revoke_all.success.single": "Se le han revocado %2$s poderes de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_from_source.success.multiple": "Se le ha revocado el poder %2$s de la fuente %2$s a %1$s entidades.",
 	"commands.apoli.revoke_from_source.success.single": "Se le ha revocado el poder %2$s de la fuente %2$s a la entidad %1$s.",
-
 	"commands.apoli.sources.fail": "La entidad %s es inerte o no tiene el poder %s.",
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
-
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-
+	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
 	"text.apoli.cannot_sleep": "You cannot sleep",
-
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
 	"text.autoconfig.power_config.option.executeCommand.showOutput": "Notificar ejecución de comandos en el chat",
-
 	"text.autoconfig.power_config.option.resourcesAndCooldowns": "Recursos y Cooldowns",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetX": "HUD Offset X",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetY": "HUD Offset Y",
-
 	"text.autoconfig.power_config.option.tooltips": "Descripción de Objetos",
 	"text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compactar descripción de Usabilidad",
 	"text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Mostrar Usabilidad",
-
 	"text.autoconfig.power_config.title": "Configuración de Apoli",
-
 	"tooltip.apoli.unusable.block.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.block.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.bow.multiple": "Inutilizable (%s)",
@@ -84,6 +63,7 @@
 	"tooltip.apoli.unusable.spyglass.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
-	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)"
-
+	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
+	"tooltip.apoli.use_preventing_powers.count": "%s powers",
+	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_ec.json
+++ b/src/main/resources/assets/apoli/lang/es_ec.json
@@ -34,7 +34,7 @@
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
+	"key.apoli.usability_hint.show_powers": "Show Powers in Usability Hints",
 	"text.apoli.cannot_sleep": "You cannot sleep",
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
@@ -64,6 +64,6 @@
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
 	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
-	"tooltip.apoli.use_preventing_powers.count": "%s powers",
-	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
+	"tooltip.apoli.usability_hint.power_count": "%s powers",
+	"tooltip.apoli.usability_hint.show_powers": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_ec.json
+++ b/src/main/resources/assets/apoli/lang/es_ec.json
@@ -1,72 +1,51 @@
 {
-
 	"argument.apoli.power_holder.not_found.multiple": "No living entities were found",
 	"argument.apoli.power_holder.not_found.single": "Entity %s is not a living entity",
-
+	"category.apoli": "Apoli",
 	"commands.apoli.clear.fail.multiple": "Ninguna de las entidades seleccionadas tenía poderes que eliminar.",
 	"commands.apoli.clear.fail.single": "La entidad %s no tenía ningún poder que eliminar.",
-
 	"commands.apoli.clear.success.multiple": "Se le han eliminado %2$s poderes a %1$s entidades.",
 	"commands.apoli.clear.success.single": "Se le han eliminado %2$s poderes a la entidad %1$s.",
-
 	"commands.apoli.grant.fail.multiple": "Todas las %s entidades ya tenían el poder %s de la fuente %s.",
 	"commands.apoli.grant.fail.single": "La entidad %s ya tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.grant.success.multiple": "Se le ha dado el poder %2$s a %1$s entidades.",
 	"commands.apoli.grant.success.single": "Se le ha dado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.grant_from_source.success.multiple": "Se le ha dado el poder %2$s de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.grant_from_source.success.single": "Se le ha dado el poder %2$s de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.list.fail": "La entidad seleccionada no está viva, así que no puede tener poderes.",
 	"commands.apoli.list.pass": "La entidad tiene %s poderes: [%s]",
-
 	"commands.apoli.list.sources": "Sources: [%s]",
 	"commands.apoli.power_not_found": "Unknown power: %s",
-
 	"commands.apoli.remove.fail.multiple": "Ninguna de las entidades tenía el poder %s.",
 	"commands.apoli.remove.fail.single": "La entidad %s no tenía el poder %s.",
-
 	"commands.apoli.remove.success.multiple": "Se le ha removido el poder %2$s a %1$s entidades.",
 	"commands.apoli.remove.success.single": "Se le ha removido el poder %2$s a la entidad %1$s",
-
 	"commands.apoli.revoke.fail.multiple": "Ninguna de las entidades seleccionadas tenía el poder %s de la fuente %s.",
 	"commands.apoli.revoke.fail.single": "La entidad %s no tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.revoke.success.multiple": "Se le ha revocado el poder %2$s a %1$s entidades.",
 	"commands.apoli.revoke.success.single": "Se le ha revocado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_all.fail.multiple": "Ninguna de las entidades seleccionadas tenía algún poder de la fuente %s.",
 	"commands.apoli.revoke_all.fail.single": "La entidad %s no tenía ningún poder de la fuente %s.",
-
 	"commands.apoli.revoke_all.success.multiple": "Se le han revocado %2$s poderes de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.revoke_all.success.single": "Se le han revocado %2$s poderes de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_from_source.success.multiple": "Se le ha revocado el poder %2$s de la fuente %2$s a %1$s entidades.",
 	"commands.apoli.revoke_from_source.success.single": "Se le ha revocado el poder %2$s de la fuente %2$s a la entidad %1$s.",
-
 	"commands.apoli.sources.fail": "La entidad %s es inerte o no tiene el poder %s.",
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
-
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-
+	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
 	"text.apoli.cannot_sleep": "You cannot sleep",
-
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
 	"text.autoconfig.power_config.option.executeCommand.showOutput": "Notificar ejecución de comandos en el chat",
-
 	"text.autoconfig.power_config.option.resourcesAndCooldowns": "Recursos y Cooldowns",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetX": "HUD Offset X",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetY": "HUD Offset Y",
-
 	"text.autoconfig.power_config.option.tooltips": "Descripción de Objetos",
 	"text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compactar descripción de Usabilidad",
 	"text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Mostrar Usabilidad",
-
 	"text.autoconfig.power_config.title": "Configuración de Apoli",
-
 	"tooltip.apoli.unusable.block.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.block.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.bow.multiple": "Inutilizable (%s)",
@@ -84,6 +63,7 @@
 	"tooltip.apoli.unusable.spyglass.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
-	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)"
-
+	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
+	"tooltip.apoli.use_preventing_powers.count": "%s powers",
+	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_es.json
+++ b/src/main/resources/assets/apoli/lang/es_es.json
@@ -34,7 +34,7 @@
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
+	"key.apoli.usability_hint.show_powers": "Show Powers in Usability Hints",
 	"text.apoli.cannot_sleep": "You cannot sleep",
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
@@ -64,6 +64,6 @@
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
 	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
-	"tooltip.apoli.use_preventing_powers.count": "%s powers",
-	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
+	"tooltip.apoli.usability_hint.power_count": "%s powers",
+	"tooltip.apoli.usability_hint.show_powers": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_es.json
+++ b/src/main/resources/assets/apoli/lang/es_es.json
@@ -1,72 +1,51 @@
 {
-
 	"argument.apoli.power_holder.not_found.multiple": "No living entities were found",
 	"argument.apoli.power_holder.not_found.single": "Entity %s is not a living entity",
-
+	"category.apoli": "Apoli",
 	"commands.apoli.clear.fail.multiple": "Ninguna de las entidades seleccionadas tenía poderes que eliminar.",
 	"commands.apoli.clear.fail.single": "La entidad %s no tenía ningún poder que eliminar.",
-
 	"commands.apoli.clear.success.multiple": "Se le han eliminado %2$s poderes a %1$s entidades.",
 	"commands.apoli.clear.success.single": "Se le han eliminado %2$s poderes a la entidad %1$s.",
-
 	"commands.apoli.grant.fail.multiple": "Todas las %s entidades ya tenían el poder %s de la fuente %s.",
 	"commands.apoli.grant.fail.single": "La entidad %s ya tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.grant.success.multiple": "Se le ha dado el poder %2$s a %1$s entidades.",
 	"commands.apoli.grant.success.single": "Se le ha dado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.grant_from_source.success.multiple": "Se le ha dado el poder %2$s de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.grant_from_source.success.single": "Se le ha dado el poder %2$s de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.list.fail": "La entidad seleccionada no está viva, así que no puede tener poderes.",
 	"commands.apoli.list.pass": "La entidad tiene %s poderes: [%s]",
-
 	"commands.apoli.list.sources": "Sources: [%s]",
 	"commands.apoli.power_not_found": "Unknown power: %s",
-
 	"commands.apoli.remove.fail.multiple": "Ninguna de las entidades tenía el poder %s.",
 	"commands.apoli.remove.fail.single": "La entidad %s no tenía el poder %s.",
-
 	"commands.apoli.remove.success.multiple": "Se le ha removido el poder %2$s a %1$s entidades.",
 	"commands.apoli.remove.success.single": "Se le ha removido el poder %2$s a la entidad %1$s",
-
 	"commands.apoli.revoke.fail.multiple": "Ninguna de las entidades seleccionadas tenía el poder %s de la fuente %s.",
 	"commands.apoli.revoke.fail.single": "La entidad %s no tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.revoke.success.multiple": "Se le ha revocado el poder %2$s a %1$s entidades.",
 	"commands.apoli.revoke.success.single": "Se le ha revocado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_all.fail.multiple": "Ninguna de las entidades seleccionadas tenía algún poder de la fuente %s.",
 	"commands.apoli.revoke_all.fail.single": "La entidad %s no tenía ningún poder de la fuente %s.",
-
 	"commands.apoli.revoke_all.success.multiple": "Se le han revocado %2$s poderes de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.revoke_all.success.single": "Se le han revocado %2$s poderes de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_from_source.success.multiple": "Se le ha revocado el poder %2$s de la fuente %2$s a %1$s entidades.",
 	"commands.apoli.revoke_from_source.success.single": "Se le ha revocado el poder %2$s de la fuente %2$s a la entidad %1$s.",
-
 	"commands.apoli.sources.fail": "La entidad %s es inerte o no tiene el poder %s.",
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
-
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-
+	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
 	"text.apoli.cannot_sleep": "You cannot sleep",
-
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
 	"text.autoconfig.power_config.option.executeCommand.showOutput": "Notificar ejecución de comandos en el chat",
-
 	"text.autoconfig.power_config.option.resourcesAndCooldowns": "Recursos y Cooldowns",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetX": "HUD Offset X",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetY": "HUD Offset Y",
-
 	"text.autoconfig.power_config.option.tooltips": "Descripción de Objetos",
 	"text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compactar descripción de Usabilidad",
 	"text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Mostrar Usabilidad",
-
 	"text.autoconfig.power_config.title": "Configuración de Apoli",
-
 	"tooltip.apoli.unusable.block.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.block.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.bow.multiple": "Inutilizable (%s)",
@@ -84,6 +63,7 @@
 	"tooltip.apoli.unusable.spyglass.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
-	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)"
-
+	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
+	"tooltip.apoli.use_preventing_powers.count": "%s powers",
+	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_mx.json
+++ b/src/main/resources/assets/apoli/lang/es_mx.json
@@ -1,73 +1,51 @@
 {
-
 	"argument.apoli.power_holder.not_found.multiple": "No living entities were found",
 	"argument.apoli.power_holder.not_found.single": "Entity %s is not a living entity",
-
+	"category.apoli": "Apoli",
 	"commands.apoli.clear.fail.multiple": "Ninguna de las entidades seleccionadas tenía poderes que eliminar.",
 	"commands.apoli.clear.fail.single": "La entidad %s no tenía ningún poder que eliminar.",
-
 	"commands.apoli.clear.success.multiple": "Se le han eliminado %2$s poderes a %1$s entidades.",
 	"commands.apoli.clear.success.single": "Se le han eliminado %2$s poderes a la entidad %1$s.",
-
 	"commands.apoli.grant.fail.multiple": "Todas las %s entidades ya tenían el poder %s de la fuente %s.",
 	"commands.apoli.grant.fail.single": "La entidad %s ya tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.grant.success.multiple": "Se le ha dado el poder %2$s a %1$s entidades.",
 	"commands.apoli.grant.success.single": "Se le ha dado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.grant_from_source.success.multiple": "Se le ha dado el poder %2$s de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.grant_from_source.success.single": "Se le ha dado el poder %2$s de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.list.fail": "La entidad seleccionada no está viva, así que no puede tener poderes.",
 	"commands.apoli.list.pass": "La entidad tiene %s poderes: [%s]",
-
 	"commands.apoli.list.sources": "Sources: [%s]",
 	"commands.apoli.power_not_found": "Unknown power: %s",
-
 	"commands.apoli.remove.fail.multiple": "Ninguna de las entidades tenía el poder %s.",
 	"commands.apoli.remove.fail.single": "La entidad %s no tenía el poder %s.",
-
 	"commands.apoli.remove.success.multiple": "Se le ha removido el poder %2$s a %1$s entidades.",
 	"commands.apoli.remove.success.single": "Se le ha removido el poder %2$s a la entidad %1$s",
-
 	"commands.apoli.revoke.fail.multiple": "Ninguna de las entidades seleccionadas tenía el poder %s de la fuente %s.",
 	"commands.apoli.revoke.fail.single": "La entidad %s no tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.revoke.success.multiple": "Se le ha revocado el poder %2$s a %1$s entidades.",
 	"commands.apoli.revoke.success.single": "Se le ha revocado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_all.fail.multiple": "Ninguna de las entidades seleccionadas tenía algún poder de la fuente %s.",
 	"commands.apoli.revoke_all.fail.single": "La entidad %s no tenía ningún poder de la fuente %s.",
-
 	"commands.apoli.revoke_all.success.multiple": "Se le han revocado %2$s poderes de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.revoke_all.success.single": "Se le han revocado %2$s poderes de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_from_source.success.multiple": "Se le ha revocado el poder %2$s de la fuente %2$s a %1$s entidades.",
 	"commands.apoli.revoke_from_source.success.single": "Se le ha revocado el poder %2$s de la fuente %2$s a la entidad %1$s.",
-
 	"commands.apoli.sources.fail": "La entidad %s es inerte o no tiene el poder %s.",
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
-
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-
+	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
 	"text.apoli.cannot_sleep": "You cannot sleep",
-
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
 	"text.autoconfig.power_config.option.executeCommand.showOutput": "Notificar ejecución de comandos en el chat",
-
 	"text.autoconfig.power_config.option.resourcesAndCooldowns": "Recursos y Cooldowns",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetX": "HUD Offset X",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetY": "HUD Offset Y",
-
 	"text.autoconfig.power_config.option.tooltips": "Descripción de Objetos",
-
 	"text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compactar descripción de Usabilidad",
 	"text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Mostrar Usabilidad",
-
 	"text.autoconfig.power_config.title": "Configuración de Apoli",
-
 	"tooltip.apoli.unusable.block.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.block.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.bow.multiple": "Inutilizable (%s)",
@@ -85,6 +63,7 @@
 	"tooltip.apoli.unusable.spyglass.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
-	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)"
-
+	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
+	"tooltip.apoli.use_preventing_powers.count": "%s powers",
+	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_mx.json
+++ b/src/main/resources/assets/apoli/lang/es_mx.json
@@ -34,7 +34,7 @@
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
+	"key.apoli.usability_hint.show_powers": "Show Powers in Usability Hints",
 	"text.apoli.cannot_sleep": "You cannot sleep",
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
@@ -64,6 +64,6 @@
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
 	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
-	"tooltip.apoli.use_preventing_powers.count": "%s powers",
-	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
+	"tooltip.apoli.usability_hint.power_count": "%s powers",
+	"tooltip.apoli.usability_hint.show_powers": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_uy.json
+++ b/src/main/resources/assets/apoli/lang/es_uy.json
@@ -34,7 +34,7 @@
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
+	"key.apoli.usability_hint.show_powers": "Show Powers in Usability Hints",
 	"text.apoli.cannot_sleep": "You cannot sleep",
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
@@ -64,6 +64,6 @@
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
 	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
-	"tooltip.apoli.use_preventing_powers.count": "%s powers",
-	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
+	"tooltip.apoli.usability_hint.power_count": "%s powers",
+	"tooltip.apoli.usability_hint.show_powers": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_uy.json
+++ b/src/main/resources/assets/apoli/lang/es_uy.json
@@ -1,71 +1,51 @@
 {
 	"argument.apoli.power_holder.not_found.multiple": "No living entities were found",
 	"argument.apoli.power_holder.not_found.single": "Entity %s is not a living entity",
-
+	"category.apoli": "Apoli",
 	"commands.apoli.clear.fail.multiple": "Ninguna de las entidades seleccionadas tenía poderes que eliminar.",
 	"commands.apoli.clear.fail.single": "La entidad %s no tenía ningún poder que eliminar.",
-
 	"commands.apoli.clear.success.multiple": "Se le han eliminado %2$s poderes a %1$s entidades.",
 	"commands.apoli.clear.success.single": "Se le han eliminado %2$s poderes a la entidad %1$s.",
-
 	"commands.apoli.grant.fail.multiple": "Todas las %s entidades ya tenían el poder %s de la fuente %s.",
 	"commands.apoli.grant.fail.single": "La entidad %s ya tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.grant.success.multiple": "Se le ha dado el poder %2$s a %1$s entidades.",
 	"commands.apoli.grant.success.single": "Se le ha dado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.grant_from_source.success.multiple": "Se le ha dado el poder %2$s de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.grant_from_source.success.single": "Se le ha dado el poder %2$s de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.list.fail": "La entidad seleccionada no está viva, así que no puede tener poderes.",
 	"commands.apoli.list.pass": "La entidad tiene %s poderes: [%s]",
-
 	"commands.apoli.list.sources": "Sources: [%s]",
 	"commands.apoli.power_not_found": "Unknown power: %s",
-
 	"commands.apoli.remove.fail.multiple": "Ninguna de las entidades tenía el poder %s.",
 	"commands.apoli.remove.fail.single": "La entidad %s no tenía el poder %s.",
-
 	"commands.apoli.remove.success.multiple": "Se le ha removido el poder %2$s a %1$s entidades.",
 	"commands.apoli.remove.success.single": "Se le ha removido el poder %2$s a la entidad %1$s",
-
 	"commands.apoli.revoke.fail.multiple": "Ninguna de las entidades seleccionadas tenía el poder %s de la fuente %s.",
 	"commands.apoli.revoke.fail.single": "La entidad %s no tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.revoke.success.multiple": "Se le ha revocado el poder %2$s a %1$s entidades.",
 	"commands.apoli.revoke.success.single": "Se le ha revocado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_all.fail.multiple": "Ninguna de las entidades seleccionadas tenía algún poder de la fuente %s.",
 	"commands.apoli.revoke_all.fail.single": "La entidad %s no tenía ningún poder de la fuente %s.",
-
 	"commands.apoli.revoke_all.success.multiple": "Se le han revocado %2$s poderes de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.revoke_all.success.single": "Se le han revocado %2$s poderes de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_from_source.success.multiple": "Se le ha revocado el poder %2$s de la fuente %2$s a %1$s entidades.",
 	"commands.apoli.revoke_from_source.success.single": "Se le ha revocado el poder %2$s de la fuente %2$s a la entidad %1$s.",
-
 	"commands.apoli.sources.fail": "La entidad %s es inerte o no tiene el poder %s.",
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
-
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-
+	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
 	"text.apoli.cannot_sleep": "You cannot sleep",
-
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
 	"text.autoconfig.power_config.option.executeCommand.showOutput": "Notificar ejecución de comandos en el chat",
-
 	"text.autoconfig.power_config.option.resourcesAndCooldowns": "Recursos y Cooldowns",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetX": "HUD Offset X",
 	"text.autoconfig.power_config.option.resourcesAndCooldowns.hudOffsetY": "HUD Offset Y",
-
 	"text.autoconfig.power_config.option.tooltips": "Descripción de Objetos",
 	"text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compactar descripción de Usabilidad",
 	"text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Mostrar Usabilidad",
-
 	"text.autoconfig.power_config.title": "Configuración de Apoli",
-
 	"tooltip.apoli.unusable.block.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.block.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.bow.multiple": "Inutilizable (%s)",
@@ -83,6 +63,7 @@
 	"tooltip.apoli.unusable.spyglass.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
-	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)"
-
+	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
+	"tooltip.apoli.use_preventing_powers.count": "%s powers",
+	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_ve.json
+++ b/src/main/resources/assets/apoli/lang/es_ve.json
@@ -34,7 +34,7 @@
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
+	"key.apoli.usability_hint.show_powers": "Show Powers in Usability Hints",
 	"text.apoli.cannot_sleep": "You cannot sleep",
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
@@ -64,6 +64,6 @@
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
 	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
-	"tooltip.apoli.use_preventing_powers.count": "%s powers",
-	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
+	"tooltip.apoli.usability_hint.power_count": "%s powers",
+	"tooltip.apoli.usability_hint.show_powers": "Hold [%s] to show the powers"
 }

--- a/src/main/resources/assets/apoli/lang/es_ve.json
+++ b/src/main/resources/assets/apoli/lang/es_ve.json
@@ -1,58 +1,41 @@
 {
-
 	"argument.apoli.power_holder.not_found.multiple": "No living entities were found",
 	"argument.apoli.power_holder.not_found.single": "Entity %s is not a living entity",
-
+	"category.apoli": "Apoli",
 	"commands.apoli.clear.fail.multiple": "Ninguna de las entidades seleccionadas tenía poderes que eliminar.",
 	"commands.apoli.clear.fail.single": "La entidad %s no tenía ningún poder que eliminar.",
-
 	"commands.apoli.clear.success.multiple": "Se le han eliminado %2$s poderes a %1$s entidades.",
 	"commands.apoli.clear.success.single": "Se le han eliminado %2$s poderes a la entidad %1$s.",
-
 	"commands.apoli.grant.fail.multiple": "Todas las %s entidades ya tenían el poder %s de la fuente %s.",
 	"commands.apoli.grant.fail.single": "La entidad %s ya tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.grant.success.multiple": "Se le ha dado el poder %2$s a %1$s entidades.",
 	"commands.apoli.grant.success.single": "Se le ha dado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.grant_from_source.success.multiple": "Se le ha dado el poder %2$s de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.grant_from_source.success.single": "Se le ha dado el poder %2$s de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.list.fail": "La entidad seleccionada no está viva, así que no puede tener poderes.",
 	"commands.apoli.list.pass": "La entidad tiene %s poderes: [%s]",
 	"commands.apoli.list.sources": "Sources: [%s]",
-
 	"commands.apoli.power_not_found": "Unknown power: %s",
-
 	"commands.apoli.remove.fail.multiple": "Ninguna de las entidades tenía el poder %s.",
 	"commands.apoli.remove.fail.single": "La entidad %s no tenía el poder %s.",
-
 	"commands.apoli.remove.success.multiple": "Se le ha removido el poder %2$s a %1$s entidades.",
 	"commands.apoli.remove.success.single": "Se le ha removido el poder %2$s a la entidad %1$s",
-
 	"commands.apoli.revoke.fail.multiple": "Ninguna de las entidades seleccionadas tenía el poder %s de la fuente %s.",
 	"commands.apoli.revoke.fail.single": "La entidad %s no tenía el poder %s de la fuente %s.",
-
 	"commands.apoli.revoke.success.multiple": "Se le ha revocado el poder %2$s a %1$s entidades.",
 	"commands.apoli.revoke.success.single": "Se le ha revocado el poder %2$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_all.fail.multiple": "Ninguna de las entidades seleccionadas tenía algún poder de la fuente %s.",
 	"commands.apoli.revoke_all.fail.single": "La entidad %s no tenía ningún poder de la fuente %s.",
-
 	"commands.apoli.revoke_all.success.multiple": "Se le han revocado %2$s poderes de la fuente %3$s a %1$s entidades.",
 	"commands.apoli.revoke_all.success.single": "Se le han revocado %2$s poderes de la fuente %3$s a la entidad %1$s.",
-
 	"commands.apoli.revoke_from_source.success.multiple": "Se le ha revocado el poder %2$s de la fuente %2$s a %1$s entidades.",
 	"commands.apoli.revoke_from_source.success.single": "Se le ha revocado el poder %2$s de la fuente %2$s a la entidad %1$s.",
-
 	"commands.apoli.sources.fail": "La entidad %s es inerte o no tiene el poder %s.",
 	"commands.apoli.sources.pass": "La entidad %s tenía %s fuentes de las que consiguió el poder %s: [%s]",
-
 	"death.attack.genericDamageOverTime": "%1$s died to a damage over time effect",
 	"death.attack.genericDamageOverTime.player": "%1$s died to a damage over time effect whilst fighting %2$s",
-
+	"key.apoli.use_preventing_powers.show": "Show use-preventing Powers",
 	"text.apoli.cannot_sleep": "You cannot sleep",
-
 	"text.autoconfig.power_config.option.executeCommand": "Ejecución de Comandos.",
 	"text.autoconfig.power_config.option.executeCommand.permissionLevel": "Nivel de Permiso",
 	"text.autoconfig.power_config.option.executeCommand.showOutput": "Notificar ejecución de comandos en el chat",
@@ -63,7 +46,6 @@
 	"text.autoconfig.power_config.option.tooltips.compactUsabilityHints": "Compactar descripción de Usabilidad",
 	"text.autoconfig.power_config.option.tooltips.showUsabilityHints": "Mostrar Usabilidad",
 	"text.autoconfig.power_config.title": "Configuración de Apoli",
-
 	"tooltip.apoli.unusable.block.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.block.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.bow.multiple": "Inutilizable (%s)",
@@ -81,6 +63,7 @@
 	"tooltip.apoli.unusable.spyglass.multiple": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.spyglass.single": "Inutilizable (%s)",
 	"tooltip.apoli.unusable.toot_horn.multiple": "Untootable (%s)",
-	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)"
-
+	"tooltip.apoli.unusable.toot_horn.single": "Untootable (%s)",
+	"tooltip.apoli.use_preventing_powers.count": "%s powers",
+	"tooltip.apoli.use_preventing_powers.show": "Hold [%s] to show the powers"
 }


### PR DESCRIPTION
This PR changes how the `prevent_item_use` power type displays its usability hint. Most notably, the names of the powers that prevents the usage of an item can now be forcibly displayed by holding a certain keybind (Left Alt by default). It also changes the logic of counting powers, where it no longer exclude hidden powers from being counted (may be subject to change)