### PR TITLE
Update `modify_lava_speed` and `modify_swim_speed` to support Apoli's custom modifiers

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/ModifyLavaSpeedPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyLavaSpeedPower.java
@@ -3,36 +3,37 @@ package io.github.apace100.apoli.power;
 import de.dafuqs.additionalentityattributes.AdditionalEntityAttributes;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.power.factory.PowerFactory;
-import io.github.apace100.apoli.util.AttributedEntityAttributeModifier;
+import io.github.apace100.apoli.util.modifier.Modifier;
 import io.github.apace100.calio.data.SerializableData;
-import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.attribute.EntityAttributeModifier;
 
 import java.util.List;
 
-public class ModifyLavaSpeedPower extends ConditionedAttributePower {
-    public ModifyLavaSpeedPower(PowerType<?> type, LivingEntity entity) {
-        super(type, entity, 10,false);
+public class ModifyLavaSpeedPower extends ModifyAttributePower {
+
+    public ModifyLavaSpeedPower(PowerType<?> powerType, LivingEntity livingEntity, Modifier modifier, List<Modifier> modifiers) {
+        super(powerType, livingEntity, AdditionalEntityAttributes.LAVA_SPEED);
+        if (modifier != null) {
+            this.addModifier(modifier);
+        }
+        if (modifiers != null) {
+            modifiers.forEach(this::addModifier);
+        }
     }
 
     public static PowerFactory createFactory() {
-        return new PowerFactory<>(Apoli.identifier("modify_lava_speed"),
+        return new PowerFactory<>(
+            Apoli.identifier("modify_lava_speed"),
             new SerializableData()
-                .add("modifier", SerializableDataTypes.ATTRIBUTE_MODIFIER, null)
-                .add("modifiers", SerializableDataTypes.ATTRIBUTE_MODIFIERS, null),
-            data ->
-                (type, player) -> {
-                    ModifyLavaSpeedPower power = new ModifyLavaSpeedPower(type, player);
-                    data.<EntityAttributeModifier>ifPresent
-                        ("modifier", mod -> power.addModifier(
-                            new AttributedEntityAttributeModifier(AdditionalEntityAttributes.LAVA_SPEED, mod)));
-                    data.<List<EntityAttributeModifier>>ifPresent("modifiers",
-                        mods -> mods.forEach(mod -> power.addModifier(
-                            new AttributedEntityAttributeModifier(AdditionalEntityAttributes.LAVA_SPEED, mod)))
-                    );
-                    return power;
-                })
-            .allowCondition();
+                .add("modifier", Modifier.DATA_TYPE, null)
+                .add("modifiers", Modifier.LIST_TYPE, null),
+            data -> (powerType, LivingEntity) -> new ModifyLavaSpeedPower(
+                powerType,
+                LivingEntity,
+                data.get("modifier"),
+                data.get("modifiers")
+            )
+        ).allowCondition();
     }
+
 }

--- a/src/main/java/io/github/apace100/apoli/power/ModifySwimSpeedPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifySwimSpeedPower.java
@@ -3,36 +3,37 @@ package io.github.apace100.apoli.power;
 import de.dafuqs.additionalentityattributes.AdditionalEntityAttributes;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.power.factory.PowerFactory;
-import io.github.apace100.apoli.util.AttributedEntityAttributeModifier;
+import io.github.apace100.apoli.util.modifier.Modifier;
 import io.github.apace100.calio.data.SerializableData;
-import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.attribute.EntityAttributeModifier;
 
 import java.util.List;
 
-public class ModifySwimSpeedPower extends ConditionedAttributePower {
-    public ModifySwimSpeedPower(PowerType<?> type, LivingEntity entity) {
-        super(type, entity, 10,false);
+public class ModifySwimSpeedPower extends ModifyAttributePower {
+
+    public ModifySwimSpeedPower(PowerType<?> powerType, LivingEntity livingEntity, Modifier modifier, List<Modifier> modifiers) {
+        super(powerType, livingEntity, AdditionalEntityAttributes.WATER_SPEED);
+        if (modifier != null) {
+            this.addModifier(modifier);
+        }
+        if (modifiers != null) {
+            modifiers.forEach(this::addModifier);
+        }
     }
 
     public static PowerFactory createFactory() {
-        return new PowerFactory<>(Apoli.identifier("modify_swim_speed"),
+        return new PowerFactory<>(
+            Apoli.identifier("modify_swim_speed"),
             new SerializableData()
-                .add("modifier", SerializableDataTypes.ATTRIBUTE_MODIFIER, null)
-                .add("modifiers", SerializableDataTypes.ATTRIBUTE_MODIFIERS, null),
-            data ->
-                (type, player) -> {
-                    ModifySwimSpeedPower power = new ModifySwimSpeedPower(type, player);
-                    data.<EntityAttributeModifier>ifPresent
-                        ("modifier", mod -> power.addModifier(
-                            new AttributedEntityAttributeModifier(AdditionalEntityAttributes.WATER_SPEED, mod)));
-                    data.<List<EntityAttributeModifier>>ifPresent("modifiers",
-                        mods -> mods.forEach(mod -> power.addModifier(
-                            new AttributedEntityAttributeModifier(AdditionalEntityAttributes.WATER_SPEED, mod)))
-                    );
-                    return power;
-                })
-            .allowCondition();
+                .add("modifier", Modifier.DATA_TYPE, null)
+                .add("modifiers", Modifier.LIST_TYPE, null),
+            data -> (powerType, livingEntity) -> new ModifySwimSpeedPower(
+                powerType,
+                livingEntity,
+                data.get("modifier"),
+                data.get("modifier")
+            )
+        ).allowCondition();
     }
+
 }


### PR DESCRIPTION
This PR updates the `modify_lava_speed` and `modify_swim_speed` power types to support Apoli's custom modifiers by making the classes for said power types extend `ModifyAttributePower` instead of `ConditionedAttributePower`. This, however, have the potential of being a bit less performant