### PR TITLE
Add `icon_index` field to HUD renders

### DIFF
--- a/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
+++ b/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
@@ -207,12 +207,14 @@ public class ApoliDataTypes {
             SerializableData()
             .add("should_render", SerializableDataTypes.BOOLEAN, true)
             .add("bar_index", SerializableDataTypes.INT, 0)
-            .add("sprite_location", SerializableDataTypes.IDENTIFIER, new Identifier("origins", "textures/gui/resource_bar.png"))
+            .add("icon_index", SerializableDataTypes.INT, 0)
+            .add("sprite_location", SerializableDataTypes.IDENTIFIER, new Identifier("apoli", "textures/gui/resource_bar.png"))
             .add("condition", ENTITY_CONDITION, null)
             .add("inverted", SerializableDataTypes.BOOLEAN, false),
         (dataInst) -> new HudRender(
             dataInst.getBoolean("should_render"),
             dataInst.getInt("bar_index"),
+            dataInst.getInt("icon_index"),
             dataInst.getId("sprite_location"),
             dataInst.get("condition"),
             dataInst.getBoolean("inverted")),
@@ -220,6 +222,7 @@ public class ApoliDataTypes {
             SerializableData.Instance dataInst = data.new Instance();
             dataInst.set("should_render", inst.shouldRender());
             dataInst.set("bar_index", inst.getBarIndex());
+            dataInst.set("icon_index", inst.getIconIndex());
             dataInst.set("sprite_location", inst.getSpriteLocation());
             dataInst.set("condition", inst.getCondition());
             dataInst.set("inverted", inst.isInverted());

--- a/src/main/java/io/github/apace100/apoli/util/HudRender.java
+++ b/src/main/java/io/github/apace100/apoli/util/HudRender.java
@@ -8,17 +8,19 @@ import net.minecraft.util.Identifier;
 
 public class HudRender {
 
-    public static final HudRender DONT_RENDER = new HudRender(false, 0, Apoli.identifier("textures/gui/resource_bar.png"), null, false);
+    public static final HudRender DONT_RENDER = new HudRender(false, 0, 0, Apoli.identifier("textures/gui/resource_bar.png"), null, false);
 
     private final boolean shouldRender;
     private final int barIndex;
+    private final int iconIndex;
     private final Identifier spriteLocation;
     private final ConditionFactory<LivingEntity>.Instance playerCondition;
     private final boolean inverted;
 
-    public HudRender(boolean shouldRender, int barIndex, Identifier spriteLocation, ConditionFactory<LivingEntity>.Instance condition, boolean inverted) {
+    public HudRender(boolean shouldRender, int barIndex, int iconIndex, Identifier spriteLocation, ConditionFactory<LivingEntity>.Instance condition, boolean inverted) {
         this.shouldRender = shouldRender;
         this.barIndex = barIndex;
+        this.iconIndex = iconIndex;
         this.spriteLocation = spriteLocation;
         this.playerCondition = condition;
         this.inverted = inverted;
@@ -30,6 +32,10 @@ public class HudRender {
 
     public int getBarIndex() {
         return barIndex;
+    }
+
+    public int getIconIndex() {
+        return iconIndex;
     }
 
     public boolean isInverted() {


### PR DESCRIPTION
This PR adds an `icon_index` field to HUD renders, which is similar to `bar_index`, except instead of selecting bar sprites by index, it would be selecting icon sprites by index. Icon sprites should be separated by 1 pixel *(subject to change)* in the sprite sheet