### PR TITLE
Added Click Type to Item On Item power

### DIFF
--- a/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
+++ b/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
@@ -31,6 +31,7 @@ import net.minecraft.fluid.FluidState;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.command.AdvancementCommand;
+import net.minecraft.util.ClickType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
 import net.minecraft.util.math.BlockPos;
@@ -259,6 +260,8 @@ public class ApoliDataTypes {
     public static final SerializableDataType<AdvancementCommand.Selection> ADVANCEMENT_SELECTION = SerializableDataType.enumValue(AdvancementCommand.Selection.class);
 
     public static final SerializableDataType<List<LegacyMaterial>> LEGACY_MATERIALS = SerializableDataType.list(LEGACY_MATERIAL);
+
+    public static final SerializableDataType<ClickType> CLICK_TYPE = SerializableDataType.enumValue(ClickType.class);
 
     public static <T> SerializableDataType<ConditionFactory<T>.Instance> condition(Class<ConditionFactory<T>.Instance> dataClass, ConditionType<T> conditionType) {
         return new SerializableDataType<>(dataClass, conditionType::write, conditionType::read, conditionType::read);

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemMixin.java
@@ -40,12 +40,8 @@ public class ItemMixin {
         if(cir.getReturnValue()) {
             return;
         }
-        if (clickType != ClickType.RIGHT) {
-            return;
-        }
-        List<ItemOnItemPower> powers = PowerHolderComponent.getPowers(player, ItemOnItemPower.class).stream().filter(p -> p.doesApply(otherStack, stack)).collect(Collectors.toList());
-        for (ItemOnItemPower p :
-            powers) {
+        List<ItemOnItemPower> powers = PowerHolderComponent.getPowers(player, ItemOnItemPower.class).stream().filter(p -> p.doesApply(otherStack, stack, clickType)).collect(Collectors.toList());
+        for (ItemOnItemPower p : powers) {
             p.execute(otherStack, stack, slot);
         }
         if(powers.size() > 0) {


### PR DESCRIPTION
Adds a click type field to Item On Item powers, which determines if the interaction should happen on a left click, or a right click, defaulting to right clicking.