### PR TITLE
Add `edible_item` power type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/access/PotentiallyEdibleItemStack.java
+++ b/src/main/java/io/github/apace100/apoli/access/PotentiallyEdibleItemStack.java
@@ -1,0 +1,9 @@
+package io.github.apace100.apoli.access;
+
+import net.minecraft.item.FoodComponent;
+
+import java.util.Optional;
+
+public interface PotentiallyEdibleItemStack {
+    Optional<FoodComponent> apoli$getFoodComponent();
+}

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemMixin.java
@@ -1,6 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
-import io.github.apace100.apoli.access.PotentiallyEdibleItemStack;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.ItemOnItemPower;
 import io.github.apace100.apoli.power.ModifyFoodPower;
@@ -21,16 +21,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.List;
 
 @Mixin(Item.class)
-public abstract class ItemMixin implements PotentiallyEdibleItemStack {
+public abstract class ItemMixin {
 
-    @Inject(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/TypedActionResult;fail(Ljava/lang/Object;)Lnet/minecraft/util/TypedActionResult;"), cancellable = true)
-    private void tryItemAlwaysEdible(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<TypedActionResult<ItemStack>> cir) {
-        ItemStack itemStack = user.getStackInHand(hand);
-        if (PowerHolderComponent.KEY.get(user).getPowers(ModifyFoodPower.class).stream()
-            .anyMatch(p -> p.doesMakeAlwaysEdible() && p.doesApply(itemStack))) {
-            user.setCurrentHand(hand);
-            cir.setReturnValue(TypedActionResult.consume(itemStack));
+    @ModifyExpressionValue(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/TypedActionResult;fail(Ljava/lang/Object;)Lnet/minecraft/util/TypedActionResult;"))
+    private TypedActionResult<ItemStack> apoli$tryAlwaysMakingItemEdible(TypedActionResult<ItemStack> original, World world, PlayerEntity user, Hand hand) {
+
+        ItemStack stackInHand = user.getStackInHand(hand);
+        if (!PowerHolderComponent.hasPower(user, ModifyFoodPower.class, mfp -> mfp.doesMakeAlwaysEdible() && mfp.doesApply(stackInHand))) {
+            return original;
         }
+
+        user.setCurrentHand(hand);
+        return TypedActionResult.consume(stackInHand);
+
     }
 
     @Inject(method = "onClicked", at = @At("RETURN"), cancellable = true)

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemMixin.java
@@ -1,5 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
+import io.github.apace100.apoli.access.PotentiallyEdibleItemStack;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.ItemOnItemPower;
 import io.github.apace100.apoli.power.ModifyFoodPower;
@@ -20,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.List;
 
 @Mixin(Item.class)
-public class ItemMixin {
+public abstract class ItemMixin implements PotentiallyEdibleItemStack {
 
     @Inject(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/TypedActionResult;fail(Ljava/lang/Object;)Lnet/minecraft/util/TypedActionResult;"), cancellable = true)
     private void tryItemAlwaysEdible(World world, PlayerEntity user, Hand hand, CallbackInfoReturnable<TypedActionResult<ItemStack>> cir) {

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -1,18 +1,26 @@
 package io.github.apace100.apoli.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import io.github.apace100.apoli.access.EntityLinkedItemStack;
 import io.github.apace100.apoli.access.MutableItemStack;
+import io.github.apace100.apoli.access.PotentiallyEdibleItemStack;
 import io.github.apace100.apoli.component.PowerHolderComponent;
-import io.github.apace100.apoli.power.*;
+import io.github.apace100.apoli.power.ActionOnItemUsePower;
+import io.github.apace100.apoli.power.EdibleItemPower;
+import io.github.apace100.apoli.power.PreventItemUsePower;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.FoodComponent;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
+import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -24,8 +32,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import java.util.Comparator;
+import java.util.Optional;
+
 @Mixin(ItemStack.class)
-public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedItemStack {
+public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedItemStack, PotentiallyEdibleItemStack {
 
     @Shadow @Deprecated private Item item;
 
@@ -37,7 +48,11 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
 
     @Shadow public abstract @Nullable Entity getHolder();
 
-    @Shadow public abstract void setHolder(@Nullable Entity holder);
+    @Shadow public abstract Item getItem();
+
+    @Shadow public abstract boolean isEmpty();
+
+    @Shadow public abstract ItemStack copy();
 
     @Unique
     private ItemStack apoli$usedItemStack;
@@ -62,6 +77,30 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
     @Override
     public void apoli$setEntity(Entity entity) {
         this.apoli$holdingEntity = entity;
+    }
+
+    @Override
+    public Optional<FoodComponent> apoli$getFoodComponent() {
+        return apoli$getEdiblePower()
+            .map(EdibleItemPower::getFoodComponent)
+            .or(() -> Optional.ofNullable(this.getItem().getFoodComponent()));
+    }
+
+    @Unique
+    private Optional<EdibleItemPower> apoli$getEdiblePower() {
+
+        EdibleItemPower edibleItemPower = PowerHolderComponent.getPowers(apoli$getEntity(), EdibleItemPower.class)
+            .stream()
+            .filter(p -> p.doesApply((ItemStack) (Object) this))
+            .max(Comparator.comparing(EdibleItemPower::getPriority))
+            .orElse(null);
+
+        if (edibleItemPower == null || (this.getItem().isFood() && edibleItemPower.getPriority() <= 0)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(edibleItemPower);
+
     }
 
     @Inject(method = "copy", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;setBobbingAnimationTime(I)V", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
@@ -157,6 +196,92 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
             ActionOnItemUsePower.executeActions(user, (ItemStack)(Object)this, (ItemStack)(Object)this,
                     ActionOnItemUsePower.TriggerType.DURING, ActionOnItemUsePower.PriorityPhase.AFTER);
         }
+    }
+
+    @ModifyReturnValue(method = "getUseAction", at = @At("RETURN"))
+    private UseAction apoli$replaceUseAction(UseAction original) {
+        return apoli$getEdiblePower()
+            .map(p -> p.getConsumeAnimation().getAction())
+            .orElse(original);
+    }
+
+    @ModifyReturnValue(method = "getEatSound", at = @At("RETURN"))
+    private SoundEvent apoli$replaceEatingSound(SoundEvent original) {
+        return apoli$getEdiblePower()
+            .map(EdibleItemPower::getConsumeSoundEvent)
+            .orElse(original);
+    }
+
+    @ModifyReturnValue(method = "getDrinkSound", at = @At("RETURN"))
+    private SoundEvent apoli$replaceDrinkingSound(SoundEvent original) {
+        return apoli$getEdiblePower()
+            .map(EdibleItemPower::getConsumeSoundEvent)
+            .orElse(original);
+    }
+
+    @ModifyReturnValue(method = "getMaxUseTime", at = @At("RETURN"))
+    private int apoli$modifyMaxConsumingTime(int original) {
+        return apoli$getEdiblePower()
+            .map(p -> p.getFoodComponent().isSnack() ? 16 : 32)
+            .orElse(original);
+    }
+
+    @ModifyExpressionValue(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;use(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/TypedActionResult;"))
+    private TypedActionResult<ItemStack> apoli$consumeEdibleItem(TypedActionResult<ItemStack> original, World world, PlayerEntity user, Hand hand) {
+
+        Optional<EdibleItemPower> edibleItemPower = apoli$getEdiblePower();
+        if (edibleItemPower.isEmpty()) {
+            return original;
+        }
+
+        ItemStack handStack = user.getStackInHand(hand);
+        if (user.canConsume(edibleItemPower.get().getFoodComponent().isAlwaysEdible())) {
+            user.setCurrentHand(hand);
+        }
+
+        return TypedActionResult.consume(handStack);
+
+    }
+
+    @ModifyReturnValue(method = "finishUsing", at = @At("RETURN"))
+    private ItemStack apoli$afterConsuming(ItemStack original, World world, LivingEntity user) {
+
+        EdibleItemPower edibleItemPower = apoli$getEdiblePower().orElse(null);
+        if (edibleItemPower == null) {
+            return original;
+        }
+
+        edibleItemPower.executeEntityAction();
+
+        ItemStack newStack = user.eatFood(world, this.copy());
+        ItemStack resultStack = null;
+
+        boolean matching = false;
+
+        tryOfferingResultStack:
+        if (user instanceof PlayerEntity playerEntity && !playerEntity.isCreative()) {
+
+            resultStack = edibleItemPower.getResultStack();
+            if (resultStack == null) {
+                break tryOfferingResultStack;
+            }
+
+            edibleItemPower.executeItemAction(resultStack);
+            matching = ItemStack.canCombine(resultStack, newStack);
+
+        }
+
+        if (!matching && (!(user instanceof PlayerEntity playerEntity) || !playerEntity.isCreative())) {
+            newStack.decrement(1);
+        }
+
+        if (newStack.isEmpty() && resultStack != null) {
+            return resultStack;
+        }
+
+        edibleItemPower.executeItemAction(newStack);
+        return newStack;
+
     }
 
     @Override

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -82,9 +82,7 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
 
     @Override
     public Optional<FoodComponent> apoli$getFoodComponent() {
-        return apoli$getEdiblePower()
-            .map(EdibleItemPower::getFoodComponent)
-            .or(() -> Optional.ofNullable(this.getItem().getFoodComponent()));
+        return apoli$getEdiblePower().map(EdibleItemPower::getFoodComponent);
     }
 
     @Unique

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -275,7 +275,9 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
                 break tryOfferingResultStack;
             }
 
-            InventoryUtil.throwItem(user, resultStack, false, false);
+            if (!(user instanceof PlayerEntity)) {
+                InventoryUtil.throwItem(user, resultStack, false, false);
+            }
 
         }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -1,7 +1,8 @@
 package io.github.apace100.apoli.mixin;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import io.github.apace100.apoli.access.EntityLinkedItemStack;
 import io.github.apace100.apoli.access.MutableItemStack;
 import io.github.apace100.apoli.access.PotentiallyEdibleItemStack;
@@ -225,17 +226,17 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
             .orElse(original);
     }
 
-    @ModifyExpressionValue(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;use(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/TypedActionResult;"))
-    private TypedActionResult<ItemStack> apoli$consumeCustomFood(TypedActionResult<ItemStack> original, World world, PlayerEntity user, Hand hand) {
+    @WrapOperation(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;use(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/TypedActionResult;"))
+    private TypedActionResult<ItemStack> apoli$consumeCustomFood(Item instance, World world, PlayerEntity user, Hand hand, Operation<TypedActionResult<ItemStack>> original) {
 
         EdibleItemPower edibleItemPower = apoli$getEdiblePower().orElse(null);
         if (edibleItemPower == null) {
-            return original;
+            return original.call(instance, world, user, hand);
         }
 
         ItemStack stackInHand = user.getStackInHand(hand);
         if (!user.canConsume(edibleItemPower.getFoodComponent().isAlwaysEdible())) {
-            return original;
+            return original.call(instance, world, user, hand);
         }
 
         user.setCurrentHand(hand);

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -251,6 +251,7 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
             return original;
         }
 
+        edibleItemPower.applyEffects();
         edibleItemPower.executeEntityAction();
 
         ItemStack newStack = user.eatFood(world, this.copy());
@@ -268,6 +269,10 @@ public abstract class ItemStackMixin implements MutableItemStack, EntityLinkedIt
 
             edibleItemPower.executeItemAction(resultStack);
             matching = ItemStack.canCombine(resultStack, newStack);
+
+            if (!matching) {
+                playerEntity.getInventory().offerOrDrop(resultStack);
+            }
 
         }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/PlayerEntityMixin.java
@@ -34,7 +34,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityMixin extends LivingEntity implements Nameable, CommandOutput {
@@ -70,16 +69,25 @@ public abstract class PlayerEntityMixin extends LivingEntity implements Nameable
     }
 
     @ModifyVariable(method = "eatFood", at = @At("HEAD"), argsOnly = true)
-    private ItemStack modifyEatenItemStack(ItemStack original) {
-        List<ModifyFoodPower> mfps = PowerHolderComponent.getPowers(this, ModifyFoodPower.class);
-        mfps = mfps.stream().filter(mfp -> mfp.doesApply(original)).collect(Collectors.toList());
+    private ItemStack apoli$modifyEatenItemStack(ItemStack original) {
+
         ItemStack newStack = original;
-        for(ModifyFoodPower mfp : mfps) {
-            newStack = mfp.getConsumedItemStack(newStack);
+        ModifiableFoodEntity modifiableFoodEntity = (ModifiableFoodEntity) this;
+
+        List<ModifyFoodPower> modifyFoodPowers = PowerHolderComponent.getPowers(this, ModifyFoodPower.class)
+            .stream()
+            .filter(mfp -> mfp.doesApply(original))
+            .toList();
+
+        for (ModifyFoodPower modifyFoodPower : modifyFoodPowers) {
+            newStack = modifyFoodPower.getConsumedItemStack(newStack);
         }
-        ((ModifiableFoodEntity)this).apoli$setCurrentModifyFoodPowers(mfps);
-        ((ModifiableFoodEntity)this).apoli$setOriginalFoodStack(original);
+
+        modifiableFoodEntity.apoli$setCurrentModifyFoodPowers(modifyFoodPowers);
+        modifiableFoodEntity.apoli$setOriginalFoodStack(original);
+
         return newStack;
+
     }
 
     @Unique

--- a/src/main/java/io/github/apace100/apoli/power/EdibleItemPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/EdibleItemPower.java
@@ -1,0 +1,128 @@
+package io.github.apace100.apoli.power;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataType;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.FoodComponent;
+import net.minecraft.item.ItemStack;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.Pair;
+import net.minecraft.util.UseAction;
+import net.minecraft.world.World;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public class EdibleItemPower extends Power implements Prioritized<EdibleItemPower> {
+
+    private final Consumer<Entity> entityAction;
+    private final Consumer<Pair<World, ItemStack>> itemAction;
+
+    private final Predicate<ItemStack> itemCondition;
+
+    private final FoodComponent foodComponent;
+    private final ItemStack resultStack;
+    private final ConsumeAnimation consumeAnimation;
+    private final SoundEvent consumeSoundEvent;
+
+    private final int priority;
+
+    public EdibleItemPower(PowerType<?> powerType, LivingEntity livingEntity, Consumer<Entity> entityAction, Consumer<Pair<World, ItemStack>> itemAction, Predicate<ItemStack> itemCondition, FoodComponent foodComponent, ItemStack resultStack, ConsumeAnimation consumeAnimation, SoundEvent consumeSoundEvent, int priority) {
+        super(powerType, livingEntity);
+        this.entityAction = entityAction;
+        this.itemAction = itemAction;
+        this.itemCondition = itemCondition;
+        this.foodComponent = foodComponent;
+        this.resultStack = resultStack;
+        this.consumeAnimation = consumeAnimation;
+        this.consumeSoundEvent = consumeSoundEvent;
+        this.priority = priority;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+
+    public boolean doesApply(ItemStack stack) {
+        return itemCondition == null || itemCondition.test(stack);
+    }
+
+    public void executeEntityAction() {
+        if (entityAction != null) {
+            entityAction.accept(entity);
+        }
+    }
+
+    public void executeItemAction(ItemStack stack) {
+        if (itemAction != null) {
+            itemAction.accept(new Pair<>(entity.getWorld(), stack));
+        }
+    }
+
+    public FoodComponent getFoodComponent() {
+        return foodComponent;
+    }
+
+    public ConsumeAnimation getConsumeAnimation() {
+        return consumeAnimation;
+    }
+
+    public ItemStack getResultStack() {
+        return resultStack != null ? resultStack.copy() : null;
+    }
+
+    public SoundEvent getConsumeSoundEvent() {
+        return consumeSoundEvent;
+    }
+
+    public static PowerFactory createFactory() {
+        return new PowerFactory<>(
+            Apoli.identifier("edible_item"),
+            new SerializableData()
+                .add("entity_action", ApoliDataTypes.ENTITY_ACTION, null)
+                .add("item_action", ApoliDataTypes.ITEM_ACTION, null)
+                .add("item_condition", ApoliDataTypes.ITEM_CONDITION, null)
+                .add("food_component", SerializableDataTypes.FOOD_COMPONENT)
+                .add("result_stack", SerializableDataTypes.ITEM_STACK, null)
+                .add("consume_animation", SerializableDataType.enumValue(ConsumeAnimation.class), ConsumeAnimation.EAT)
+                .add("consume_sound", SerializableDataTypes.SOUND_EVENT, SoundEvents.ENTITY_GENERIC_EAT)
+                .add("priority", SerializableDataTypes.INT, 0),
+            data -> (powerType, livingEntity) -> new EdibleItemPower(
+                powerType,
+                livingEntity,
+                data.get("entity_action"),
+                data.get("item_action"),
+                data.get("item_condition"),
+                data.get("food_component"),
+                data.get("result_stack"),
+                data.get("consume_animation"),
+                data.get("consume_sound"),
+                data.get("priority")
+            )
+        ).allowCondition();
+    }
+
+    public enum ConsumeAnimation {
+
+        EAT(UseAction.EAT),
+        DRINK(UseAction.DRINK);
+
+        final UseAction action;
+        ConsumeAnimation(UseAction action) {
+            this.action = action;
+        }
+
+        public UseAction getAction() {
+            return action;
+        }
+
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/power/EdibleItemPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/EdibleItemPower.java
@@ -112,9 +112,12 @@ public class EdibleItemPower extends Power implements Prioritized<EdibleItemPowe
                 .add("result_item_action", ApoliDataTypes.ITEM_ACTION, null)
                 .add("item_condition", ApoliDataTypes.ITEM_CONDITION, null)
                 .add("food_component", SerializableDataTypes.FOOD_COMPONENT)
-                .add("result_stack", SerializableDataTypes.ITEM_STACK, null)
-                .add("consume_animation", SerializableDataType.enumValue(ConsumeAnimation.class), ConsumeAnimation.EAT)
-                .add("consume_sound", SerializableDataTypes.SOUND_EVENT, SoundEvents.ENTITY_GENERIC_EAT)
+                .add("return_stack", SerializableDataTypes.ITEM_STACK, null)
+                .addFunctionedDefault("result_stack", SerializableDataTypes.ITEM_STACK, data -> data.get("return_stack"))
+                .add("use_action", SerializableDataType.enumValue(ConsumeAnimation.class), ConsumeAnimation.EAT)
+                .addFunctionedDefault("consume_animation", SerializableDataType.enumValue(ConsumeAnimation.class), data -> data.get("use_action"))
+                .add("sound", SerializableDataTypes.SOUND_EVENT, SoundEvents.ENTITY_GENERIC_EAT)
+                .addFunctionedDefault("consume_sound", SerializableDataTypes.SOUND_EVENT, data -> data.get("sound"))
                 .add("priority", SerializableDataTypes.INT, 0),
             data -> (powerType, livingEntity) -> new EdibleItemPower(
                 powerType,

--- a/src/main/java/io/github/apace100/apoli/power/EdibleItemPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/EdibleItemPower.java
@@ -8,6 +8,7 @@ import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.FoodComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundEvent;
@@ -64,6 +65,19 @@ public class EdibleItemPower extends Power implements Prioritized<EdibleItemPowe
         if (itemAction != null) {
             itemAction.accept(new Pair<>(entity.getWorld(), stack));
         }
+    }
+
+    public void applyEffects() {
+
+        if (entity.getWorld().isClient) {
+            return;
+        }
+
+        foodComponent.getStatusEffects()
+            .stream()
+            .filter(pair -> entity.getWorld().getRandom().nextFloat() < pair.getSecond())
+            .forEach(pair -> entity.addStatusEffect(new StatusEffectInstance(pair.getFirst())));
+
     }
 
     public FoodComponent getFoodComponent() {

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -124,6 +124,7 @@ public class PowerFactories {
         register(() -> Power.createSimpleFactory(GroundedPower::new, Apoli.identifier("grounded")));
         register(ModifyEnchantmentLevelPower::createFactory);
         register(ActionOnDeathPower::createFactory);
+        register(EdibleItemPower::createFactory);
     }
 
     private static void register(PowerFactory<?> powerFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/ItemConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/ItemConditions.java
@@ -3,7 +3,9 @@ package io.github.apace100.apoli.power.factory.condition;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.factory.condition.item.EnchantmentCondition;
+import io.github.apace100.apoli.power.factory.condition.item.FoodCondition;
 import io.github.apace100.apoli.power.factory.condition.item.FuelCondition;
+import io.github.apace100.apoli.power.factory.condition.item.MeatCondition;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.apoli.util.StackPowerUtil;
@@ -23,8 +25,7 @@ public class ItemConditions {
 
     public static void register() {
         MetaConditions.register(ApoliDataTypes.ITEM_CONDITION, ItemConditions::register);
-        register(new ConditionFactory<>(Apoli.identifier("food"), new SerializableData(),
-            (data, stack) -> stack.isFood()));
+        register(FoodCondition.getFactory());
         register(new ConditionFactory<>(Apoli.identifier("ingredient"), new SerializableData()
             .add("ingredient", SerializableDataTypes.INGREDIENT),
             (data, stack) -> ((Ingredient)data.get("ingredient")).test(stack)));
@@ -51,8 +52,7 @@ public class ItemConditions {
                 return ((Comparison)data.get("comparison")).compare(harvestLevel, data.getInt("compare_to"));
             }));
         register(EnchantmentCondition.getFactory());
-        register(new ConditionFactory<>(Apoli.identifier("meat"), new SerializableData(),
-            (data, stack) -> stack.isFood() && stack.getItem().getFoodComponent().isMeat()));
+        register(MeatCondition.getFactory());
         register(new ConditionFactory<>(Apoli.identifier("nbt"), new SerializableData()
             .add("nbt", SerializableDataTypes.NBT), (data, stack) -> NbtHelper.matches(data.get("nbt"), stack.getNbt(), true)));
         register(new ConditionFactory<>(Apoli.identifier("fireproof"), new SerializableData(),

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/item/FoodCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/item/FoodCondition.java
@@ -1,0 +1,25 @@
+package io.github.apace100.apoli.power.factory.condition.item;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.access.PotentiallyEdibleItemStack;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.item.ItemStack;
+
+public class FoodCondition {
+
+    public static boolean condition(SerializableData.Instance data, ItemStack stack) {
+        return ((PotentiallyEdibleItemStack) stack)
+            .apoli$getFoodComponent()
+            .isPresent();
+    }
+
+    public static ConditionFactory<ItemStack> getFactory() {
+        return new ConditionFactory<>(
+            Apoli.identifier("food"),
+            new SerializableData(),
+            FoodCondition::condition
+        );
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/item/MeatCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/item/MeatCondition.java
@@ -1,0 +1,27 @@
+package io.github.apace100.apoli.power.factory.condition.item;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.access.PotentiallyEdibleItemStack;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.item.FoodComponent;
+import net.minecraft.item.ItemStack;
+
+public class MeatCondition {
+
+    public static boolean condition(SerializableData.Instance data, ItemStack stack) {
+        return ((PotentiallyEdibleItemStack) stack)
+            .apoli$getFoodComponent()
+            .map(FoodComponent::isMeat)
+            .orElse(false);
+    }
+
+    public static ConditionFactory<ItemStack> getFactory() {
+        return new ConditionFactory<>(
+            Apoli.identifier("meat"),
+            new SerializableData(),
+            MeatCondition::condition
+        );
+    }
+
+}

--- a/src/test/resources/data/apoli/powers/edible_axolotl.json
+++ b/src/test/resources/data/apoli/powers/edible_axolotl.json
@@ -1,0 +1,30 @@
+{
+	"type": "apoli:edible_item",
+	"item_condition": {
+		"type": "apoli:ingredient",
+		"ingredient": {
+			"item": "minecraft:axolotl_bucket"
+		}
+	},
+	"food_component": {
+		"hunger": 8,
+		"saturation": 2.5,
+		"meat": true
+	},
+	"result_stack": {
+		"item": "minecraft:water_bucket"
+	},
+	"condition": {
+		"type": "apoli:or",
+		"conditions": [
+			{
+				"type": "apoli:raycast",
+				"block": true,
+				"inverted": true
+			},
+			{
+				"type": "apoli:sneaking"
+			}
+		]
+	}
+}


### PR DESCRIPTION
This PR adds an `edible_item` power type similar to Apugli's `edible_item` power type, where items that fulfill the specified item condition will be made edible