### PR TITLE
Polish Modify Enchantment Level Implementation

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/EnchantmentHelperMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/EnchantmentHelperMixin.java
@@ -1,5 +1,7 @@
 package io.github.apace100.apoli.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import io.github.apace100.apoli.access.EntityLinkedItemStack;
 import io.github.apace100.apoli.power.ModifyEnchantmentLevelPower;
 import net.minecraft.enchantment.Enchantment;
@@ -19,54 +21,29 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(EnchantmentHelper.class)
 public class EnchantmentHelperMixin {
 
-    @Redirect(method = "forEachEnchantment(Lnet/minecraft/enchantment/EnchantmentHelper$Consumer;Lnet/minecraft/item/ItemStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
-    private static boolean forEachIsEmpty(ItemStack instance) {
-        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
-            return false;
-        }
-        return instance.isEmpty();
-    }
-
-    @Unique
-    private static ItemStack apugli$runIterationOnItem;
-
-    @Inject(method = "forEachEnchantment(Lnet/minecraft/enchantment/EnchantmentHelper$Consumer;Lnet/minecraft/item/ItemStack;)V", at = @At(value = "HEAD"))
-    private static void getEnchantmentItemStack(EnchantmentHelper.Consumer enchantmentVisitor, ItemStack itemStack, CallbackInfo ci) {
-        apugli$runIterationOnItem = itemStack;
+    @ModifyExpressionValue(method = "forEachEnchantment(Lnet/minecraft/enchantment/EnchantmentHelper$Consumer;Lnet/minecraft/item/ItemStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
+    private static boolean forEachIsEmpty(boolean original, EnchantmentHelper.Consumer consumer, ItemStack stack) {
+        return original || !(((EntityLinkedItemStack) stack).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living));
     }
 
     @ModifyVariable(method = "forEachEnchantment(Lnet/minecraft/enchantment/EnchantmentHelper$Consumer;Lnet/minecraft/item/ItemStack;)V", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/item/ItemStack;getEnchantments()Lnet/minecraft/nbt/NbtList;"))
-    private static NbtList getEnchantmentsForEachEnchantment(NbtList original) {
-        return ModifyEnchantmentLevelPower.getEnchantments(apugli$runIterationOnItem, original);
+    private static NbtList getEnchantmentsForEachEnchantment(NbtList original, EnchantmentHelper.Consumer consumer, ItemStack stack) {
+        return ModifyEnchantmentLevelPower.getEnchantments(stack, original);
     }
 
-    @Unique
-    private static ItemStack apugli$itemEnchantmentLevelStack;
-
-    @Inject(method = "getLevel", at = @At("HEAD"))
-    private static void getEnchantmentItemStack(Enchantment enchantment, ItemStack itemStack, CallbackInfoReturnable<Integer> cir) {
-        apugli$itemEnchantmentLevelStack = itemStack;
-    }
-
-    @Redirect(method = "getLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
-    private static boolean getLevelIsEmpty(ItemStack instance) {
-        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
-            return false;
-        }
-        return instance.isEmpty();
+    @ModifyExpressionValue(method = "getLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
+    private static boolean getLevelIsEmpty(boolean original, Enchantment enchantment, ItemStack stack) {
+        return original || !(((EntityLinkedItemStack) stack).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living));
     }
 
     @ModifyVariable(method = "getLevel", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/item/ItemStack;getEnchantments()Lnet/minecraft/nbt/NbtList;"))
-    private static NbtList getEnchantmentsGetLevel(NbtList original) {
-        return ModifyEnchantmentLevelPower.getEnchantments(apugli$itemEnchantmentLevelStack, original);
+    private static NbtList getEnchantmentsGetLevel(NbtList original, Enchantment enchantment, ItemStack stack) {
+        return ModifyEnchantmentLevelPower.getEnchantments(stack, original);
     }
 
-    @Redirect(method = "chooseEquipmentWith(Lnet/minecraft/enchantment/Enchantment;Lnet/minecraft/entity/LivingEntity;Ljava/util/function/Predicate;)Ljava/util/Map$Entry;", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
-    private static boolean allowEmptyEquipmentChoosing(ItemStack instance) {
-        if (instance.isEmpty() && ((EntityLinkedItemStack) instance).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
-            return false;
-        }
-        return instance.isEmpty();
+    @ModifyExpressionValue(method = "chooseEquipmentWith(Lnet/minecraft/enchantment/Enchantment;Lnet/minecraft/entity/LivingEntity;Ljava/util/function/Predicate;)Ljava/util/Map$Entry;", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
+    private static boolean allowEmptyEquipmentChoosing(boolean original, @Local ItemStack stack) {
+        return original || !(((EntityLinkedItemStack) stack).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living));
     }
 
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/EnchantmentMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/EnchantmentMixin.java
@@ -1,5 +1,7 @@
 package io.github.apace100.apoli.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import io.github.apace100.apoli.access.EntityLinkedItemStack;
 import io.github.apace100.apoli.power.ModifyEnchantmentLevelPower;
 import net.minecraft.enchantment.Enchantment;
@@ -18,19 +20,8 @@ import java.util.Map;
 
 @Mixin(Enchantment.class)
 public class EnchantmentMixin {
-    @Unique
-    private ItemStack apoli$capturedItem;
-
-    @Inject(method = "getEquipment", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void captureSlotItem(LivingEntity entity, CallbackInfoReturnable<Map<EquipmentSlot, ItemStack>> cir, Map map, EquipmentSlot[] var3, int var4, int var5, EquipmentSlot equipmentSlot, ItemStack stack) {
-        this.apoli$capturedItem = stack;
-    }
-
-    @Redirect(method = "getEquipment", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
-    private boolean allowEmptySlotItemIfModified(ItemStack instance) {
-        if (this.apoli$capturedItem != null && this.apoli$capturedItem.isEmpty() && ((EntityLinkedItemStack)apoli$capturedItem).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living)) {
-            return false;
-        }
-        return instance.isEmpty();
+    @ModifyExpressionValue(method = "getEquipment", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isEmpty()Z"))
+    private boolean allowEmptySlotItemIfModified(boolean original, @Local ItemStack stack) {
+        return original || !(((EntityLinkedItemStack)stack).apoli$getEntity() instanceof LivingEntity living && ModifyEnchantmentLevelPower.isInEnchantmentMap(living));
     }
 }

--- a/src/main/java/io/github/apace100/apoli/util/InventoryUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/InventoryUtil.java
@@ -7,7 +7,6 @@ import io.github.apace100.apoli.power.InventoryPower;
 import io.github.apace100.apoli.power.factory.action.ActionFactory;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.util.ArgumentWrapper;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;


### PR DESCRIPTION
This PR does a few things.

- Fixes the potential ConcurrentModificationException that sometimes happens by changing the HashMap to a ConcurrentHashMap.
- Updates the implementation mixins to utilise Mixin Extras and to remove local captures in favour of including the parameters and `@Local` annotated parameters.
- Empty ItemStacks will now not repeatedly be set, instead being set only when they aren't an individualised empty stack.