### PR TITLE
Update `add_velocity` bi-entity action type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/action/BiEntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/BiEntityActions.java
@@ -4,12 +4,11 @@ package io.github.apace100.apoli.power.factory.action;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.networking.ModPackets;
+import io.github.apace100.apoli.power.factory.action.bientity.AddVelocityAction;
 import io.github.apace100.apoli.power.factory.action.meta.*;
 import io.github.apace100.apoli.power.factory.action.bientity.DamageAction;
 import io.github.apace100.apoli.registry.ApoliRegistries;
-import io.github.apace100.apoli.util.Space;
 import io.github.apace100.calio.data.SerializableData;
-import io.github.apace100.calio.data.SerializableDataTypes;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
@@ -19,9 +18,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Pair;
-import org.joml.Vector3f;
 import net.minecraft.registry.Registry;
-import org.apache.logging.log4j.util.TriConsumer;
 
 public class BiEntityActions {
 
@@ -76,27 +73,7 @@ public class BiEntityActions {
                     }
                 }
             }));
-        register(new ActionFactory<>(Apoli.identifier("add_velocity"), new SerializableData()
-            .add("x", SerializableDataTypes.FLOAT, 0F)
-            .add("y", SerializableDataTypes.FLOAT, 0F)
-            .add("z", SerializableDataTypes.FLOAT, 0F)
-            .add("client", SerializableDataTypes.BOOLEAN, true)
-            .add("server", SerializableDataTypes.BOOLEAN, true)
-            .add("set", SerializableDataTypes.BOOLEAN, false),
-            (data, entities) -> {
-                Entity actor = entities.getLeft(), target = entities.getRight();
-                if (target instanceof PlayerEntity
-                    && (target.getWorld().isClient ?
-                        !data.getBoolean("client") : !data.getBoolean("server")))
-                    return;
-                Vector3f vec = new Vector3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z"));
-                TriConsumer<Float, Float, Float> method = target::addVelocity;
-                if(data.getBoolean("set"))
-                    method = target::setVelocity;
-                Space.transformVectorToBase(target.getPos().subtract(actor.getPos()), vec, actor.getYaw(), true); // vector normalized by method
-                method.accept(vec.x, vec.y, vec.z);
-                target.velocityModified = true;
-            }));
+        register(AddVelocityAction.getFactory());
         register(DamageAction.getFactory());
     }
 

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/bientity/AddVelocityAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/bientity/AddVelocityAction.java
@@ -1,0 +1,75 @@
+package io.github.apace100.apoli.power.factory.action.bientity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.apoli.util.Space;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataType;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Pair;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import org.apache.logging.log4j.util.TriConsumer;
+import org.joml.Vector3f;
+
+public class AddVelocityAction {
+
+    public static void action(SerializableData.Instance data, Pair<Entity, Entity> entities) {
+
+        Entity actor = entities.getLeft(), target = entities.getRight();
+
+        if (target instanceof PlayerEntity
+                && (target.getWorld().isClient ?
+                !data.getBoolean("client") : !data.getBoolean("server")))
+            return;
+
+        Vector3f vec = new Vector3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z"));
+
+        TriConsumer<Float, Float, Float> method = target::addVelocity;
+        if(data.getBoolean("set"))
+            method = target::setVelocity;
+
+        Reference reference = data.get("reference");
+
+        Vec3d refVec = switch (reference) {
+            case ROTATION -> {
+                float yaw = actor.getYaw();
+                float pitch = actor.getPitch();
+                float  f = 0.017453292F;
+
+                float h = -MathHelper.sin(yaw * f) * MathHelper.cos(pitch * f);
+                float i = -MathHelper.sin(pitch * f);
+                float j =  MathHelper.cos(yaw * f) * MathHelper.cos(pitch * f);
+
+                yield new Vec3d(h, i, j);
+            }
+            case POSITION -> target.getPos().subtract(actor.getPos());
+        };
+
+        Space.transformVectorToBase(refVec, vec, actor.getYaw(), true); // vector normalized by method
+        method.accept(vec.x, vec.y, vec.z);
+
+        target.velocityModified = true;
+
+    }
+
+    public static ActionFactory<Pair<Entity, Entity>> getFactory() {
+        return new ActionFactory<>(Apoli.identifier("add_velocity"), new SerializableData()
+                .add("x", SerializableDataTypes.FLOAT, 0F)
+                .add("y", SerializableDataTypes.FLOAT, 0F)
+                .add("z", SerializableDataTypes.FLOAT, 0F)
+                .add("client", SerializableDataTypes.BOOLEAN, true)
+                .add("server", SerializableDataTypes.BOOLEAN, true)
+                .add("set", SerializableDataTypes.BOOLEAN, false)
+                .add("reference", SerializableDataType.enumValue(Reference.class), Reference.POSITION),
+                AddVelocityAction::action
+        );
+    }
+
+    public enum Reference {
+        POSITION, ROTATION
+    }
+
+}

--- a/src/test/resources/data/apoli/powers/pick_up.json
+++ b/src/test/resources/data/apoli/powers/pick_up.json
@@ -1,0 +1,19 @@
+{
+  "type": "apoli:action_on_entity_use",
+  "bientity_action": {
+    "type": "apoli:invert",
+    "action": {
+      "type": "apoli:mount"
+    }
+  },
+  "item_condition": {
+    "type": "apoli:empty"
+  },
+  "hands": [
+    "main_hand"
+  ],
+  "condition": {
+    "type": "apoli:sneaking",
+    "inverted": true
+  }
+}

--- a/src/test/resources/data/apoli/powers/yeet.json
+++ b/src/test/resources/data/apoli/powers/yeet.json
@@ -1,0 +1,44 @@
+{
+  "type": "apoli:active_self",
+  "cooldown": 1,
+  "key": {
+    "key": "key.use",
+    "continuous": false
+  },
+  "entity_action": {
+    "type": "apoli:passenger_action",
+    "bientity_action": {
+      "type": "apoli:and",
+      "actions": [
+        {
+          "type": "apoli:actor_action",
+          "action": {
+            "type": "apoli:dismount"
+          }
+        },
+        {
+          "type": "apoli:invert",
+          "action": {
+            "type": "apoli:delay",
+            "action": {
+              "type": "apoli:add_velocity",
+              "reference": "rotation",
+              "z": 1.2
+            },
+            "ticks": 1
+          }
+        },
+        {
+          "type": "apoli:target_action",
+          "action": {
+            "type": "apoli:swing_hand",
+            "hand": "MAIN_HAND"
+          }
+        }
+      ]
+    }
+  },
+  "condition": {
+    "type": "apoli:sneaking"
+  }
+}


### PR DESCRIPTION
I'm preemptively making this PR because I noticed that Apoli lacked something that I personally needed. The ability to use a bi-entity add velocity with the actor's rotation for the direction of the velocity applied.

I've borrowed code from the `fire_projectile` power type to make this possible, so it should function like that.

Basically what this does is that it adds a `reference` field to the `add_velocity` bi-entity action. This can be either `POSITION` or `ROTATION`, position default. Position acts like how the action did before and rotation uses the actor's rotation.

This should apply to cases where a datapack maker wants to use the entity's pitch in regards to the direction that the entity is being moved in. Currently, the pitch is not accounted for in the position reference.