### PR TITLE
Tweak `modify_crafting` and `recipe` power types

### DIFF
--- a/src/main/java/io/github/apace100/apoli/access/SlotState.java
+++ b/src/main/java/io/github/apace100/apoli/access/SlotState.java
@@ -1,0 +1,10 @@
+package io.github.apace100.apoli.access;
+
+import net.minecraft.util.Identifier;
+
+import java.util.Optional;
+
+public interface SlotState {
+    Optional<Identifier> apoli$getState();
+    void apoli$setState(Identifier state);
+}

--- a/src/main/java/io/github/apace100/apoli/mixin/CraftingResultSlotMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/CraftingResultSlotMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.RecipeInputInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.CraftingResultSlot;
-import net.minecraft.util.math.BlockPos;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -16,27 +15,26 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Optional;
-
 @Mixin(CraftingResultSlot.class)
 public class CraftingResultSlotMixin {
 
     @Shadow @Final private RecipeInputInventory input;
 
     @Inject(method = "onTakeItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/recipe/RecipeManager;getRemainingStacks(Lnet/minecraft/recipe/RecipeType;Lnet/minecraft/inventory/Inventory;Lnet/minecraft/world/World;)Lnet/minecraft/util/collection/DefaultedList;"))
-    private void testOnTakeItem(PlayerEntity player, ItemStack stack, CallbackInfo ci) {
-        if (input instanceof CraftingInventory craftingInventory)
-        {
-            if (!player.getWorld().isClient)
-            {
-                PowerCraftingInventory pci = (PowerCraftingInventory) craftingInventory;
-                if (pci.apoli$getPower() instanceof ModifyCraftingPower mcp)
-                {
-                    Optional<BlockPos> blockPos = ModifiedCraftingRecipe.getBlockFromInventory(craftingInventory);
-                    mcp.executeActions(blockPos);
-                    mcp.applyAfterCraftingItemAction(stack);
-                }
-            }
+    private void apoli$executeActionsOnTakingItem(PlayerEntity player, ItemStack stack, CallbackInfo ci) {
+
+        if (player.getWorld().isClient || !(input instanceof CraftingInventory craftingInventory)) {
+            return;
         }
+
+        PowerCraftingInventory powerCraftingInventory = (PowerCraftingInventory) craftingInventory;
+        if (powerCraftingInventory.apoli$getPower() instanceof ModifyCraftingPower modifyCraftingPower) {
+
+            modifyCraftingPower.executeActions(ModifiedCraftingRecipe.getBlockFromInventory(craftingInventory));
+            modifyCraftingPower.applyAfterCraftingItemAction(stack);
+
+        }
+
     }
+
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/CraftingResultSlotMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/CraftingResultSlotMixin.java
@@ -1,13 +1,17 @@
 package io.github.apace100.apoli.mixin;
 
 import io.github.apace100.apoli.access.PowerCraftingInventory;
+import io.github.apace100.apoli.access.SlotState;
 import io.github.apace100.apoli.power.ModifyCraftingPower;
 import io.github.apace100.apoli.util.ModifiedCraftingRecipe;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
+import net.minecraft.inventory.Inventory;
 import net.minecraft.inventory.RecipeInputInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.CraftingResultSlot;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -16,24 +20,36 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CraftingResultSlot.class)
-public class CraftingResultSlotMixin {
+public class CraftingResultSlotMixin extends Slot {
 
     @Shadow @Final private RecipeInputInventory input;
 
-    @Inject(method = "onTakeItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/recipe/RecipeManager;getRemainingStacks(Lnet/minecraft/recipe/RecipeType;Lnet/minecraft/inventory/Inventory;Lnet/minecraft/world/World;)Lnet/minecraft/util/collection/DefaultedList;"))
-    private void apoli$executeActionsOnTakingItem(PlayerEntity player, ItemStack stack, CallbackInfo ci) {
+    @Shadow @Final private PlayerEntity player;
 
-        if (player.getWorld().isClient || !(input instanceof CraftingInventory craftingInventory)) {
+    public CraftingResultSlotMixin(Inventory inventory, int index, int x, int y) {
+        super(inventory, index, x, y);
+    }
+
+    @Inject(method = "onCrafted(Lnet/minecraft/item/ItemStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;onCraft(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;I)V"))
+    private void apoli$executeActionsOnCraftingItem(ItemStack stack, CallbackInfo ci) {
+
+        if (this.player.getWorld().isClient || !(input instanceof CraftingInventory craftingInventory)) {
             return;
         }
 
         PowerCraftingInventory powerCraftingInventory = (PowerCraftingInventory) craftingInventory;
-        if (powerCraftingInventory.apoli$getPower() instanceof ModifyCraftingPower modifyCraftingPower) {
+        SlotState slotState = (SlotState) this;
 
-            modifyCraftingPower.executeActions(ModifiedCraftingRecipe.getBlockFromInventory(craftingInventory));
-            modifyCraftingPower.applyAfterCraftingItemAction(stack);
-
+        if (!(powerCraftingInventory.apoli$getPower() instanceof ModifyCraftingPower modifyCraftingPower)) {
+            return;
         }
+
+        modifyCraftingPower.executeActions(ModifiedCraftingRecipe.getBlockFromInventory(craftingInventory));
+        if (slotState.apoli$getState().map(id -> !id.equals(new Identifier("apoli:modified_result_stack"))).orElse(true)) {
+            modifyCraftingPower.applyAfterCraftingItemAction(stack);
+        }
+
+        slotState.apoli$setState(null);
 
     }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/CraftingScreenHandlerMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/CraftingScreenHandlerMixin.java
@@ -1,5 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import io.github.apace100.apoli.access.PowerCraftingInventory;
 import io.github.apace100.apoli.power.ModifyCraftingPower;
 import net.minecraft.entity.player.PlayerEntity;
@@ -29,23 +30,33 @@ public class CraftingScreenHandlerMixin {
     @Shadow @Final private RecipeInputInventory input;
 
     @Inject(method = "updateResult", at = @At(value = "INVOKE", target = "Lnet/minecraft/recipe/RecipeManager;getFirstMatch(Lnet/minecraft/recipe/RecipeType;Lnet/minecraft/inventory/Inventory;Lnet/minecraft/world/World;)Ljava/util/Optional;"))
-    private static void clearPowerCraftingInventory(ScreenHandler handler, World world, PlayerEntity player, RecipeInputInventory inventory, CraftingResultInventory resultInventory, CallbackInfo ci) {
-        if (inventory instanceof CraftingInventory craftingInventory) ((PowerCraftingInventory)craftingInventory).apoli$setPower(null);
+    private static void apoli$clearPowerCraftingInventory(ScreenHandler handler, World world, PlayerEntity player, RecipeInputInventory inventory, CraftingResultInventory resultInventory, CallbackInfo ci) {
+
+        if (inventory instanceof CraftingInventory craftingInventory) {
+            ((PowerCraftingInventory) craftingInventory).apoli$setPower(null);
+        }
+
     }
 
-    @Inject(method = "canUse", at = @At("HEAD"), cancellable = true)
-    private void allowUsingViaPower(PlayerEntity player, CallbackInfoReturnable<Boolean> cir) {
-        if(context.get((world, pos) -> pos.equals(player.getBlockPos()), false)) {
-            cir.setReturnValue(true);
-        }
+    @ModifyReturnValue(method = "canUse", at = @At("RETURN"))
+    private boolean apoli$allowUsingViaPower(boolean original, PlayerEntity playerEntity) {
+        return original || context.get((world, pos) -> pos.equals(playerEntity.getBlockPos()), false);
     }
 
     @Inject(method = "quickMove", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;copy()Lnet/minecraft/item/ItemStack;", shift = At.Shift.AFTER), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void modifyOutputItems(PlayerEntity player, int index, CallbackInfoReturnable<ItemStack> cir, ItemStack itemStack, Slot slot, ItemStack itemStack2) {
+    private void apoli$modifyResultStack(PlayerEntity player, int index, CallbackInfoReturnable<ItemStack> cir, ItemStack itemStack, Slot slot, ItemStack itemStack2) {
+
+        /*
+            FIXME: Currently, this does not account for whether the item can be inserted into the player's inventory,
+                   resulting in the item action being executed
+        */
         if(input instanceof PowerCraftingInventory pci) {
+
             if(pci.apoli$getPower() instanceof ModifyCraftingPower mcp) {
                 mcp.applyAfterCraftingItemAction(itemStack2);
             }
+
         }
+
     }
 }

--- a/src/main/java/io/github/apace100/apoli/mixin/SlotMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/SlotMixin.java
@@ -1,0 +1,27 @@
+package io.github.apace100.apoli.mixin;
+
+import io.github.apace100.apoli.access.SlotState;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.Optional;
+
+@Mixin(Slot.class)
+public abstract class SlotMixin implements SlotState {
+
+    @Unique
+    private Identifier apoli$state;
+
+    @Override
+    public Optional<Identifier> apoli$getState() {
+        return Optional.ofNullable(apoli$state);
+    }
+
+    @Override
+    public void apoli$setState(Identifier state) {
+        this.apoli$state = state;
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/power/ModifyCraftingPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyCraftingPower.java
@@ -7,10 +7,7 @@ import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.CraftingRecipe;
-import net.minecraft.recipe.Recipe;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Pair;
 import net.minecraft.util.math.BlockPos;
@@ -22,73 +19,74 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-public class ModifyCraftingPower extends ValueModifyingPower {
+public class ModifyCraftingPower extends ValueModifyingPower implements Prioritized<ModifyCraftingPower> {
 
     private final Identifier recipeIdentifier;
     private final Predicate<ItemStack> itemCondition;
 
     private final ItemStack newStack;
     private final Consumer<Pair<World, ItemStack>> itemAction;
-    private final Consumer<Pair<World, ItemStack>> lateItemAction;
+    private final Consumer<Pair<World, ItemStack>> itemActionAfterCrafting;
     private final Consumer<Entity> entityAction;
     private final Consumer<Triple<World, BlockPos, Direction>> blockAction;
 
-    public ModifyCraftingPower(PowerType<?> type, LivingEntity entity, Identifier recipeIdentifier, Predicate<ItemStack> itemCondition, ItemStack newStack, Consumer<Pair<World, ItemStack>> itemAction, Consumer<Pair<World, ItemStack>> lateItemAction, Consumer<Entity> entityAction, Consumer<Triple<World, BlockPos, Direction>> blockAction) {
+    private final int priority;
+
+    public ModifyCraftingPower(PowerType<?> type, LivingEntity entity, Identifier recipeIdentifier, Predicate<ItemStack> itemCondition, ItemStack newStack, Consumer<Pair<World, ItemStack>> itemAction, Consumer<Pair<World, ItemStack>> itemActionAfterCrafting, Consumer<Entity> entityAction, Consumer<Triple<World, BlockPos, Direction>> blockAction, int priority) {
         super(type, entity);
         this.recipeIdentifier = recipeIdentifier;
         this.itemCondition = itemCondition;
         this.newStack = newStack;
         this.itemAction = itemAction;
-        this.lateItemAction = lateItemAction;
+        this.itemActionAfterCrafting = itemActionAfterCrafting;
         this.entityAction = entityAction;
         this.blockAction = blockAction;
+        this.priority = priority;
     }
 
-    public boolean doesApply(CraftingInventory inventory, CraftingRecipe recipe) {
-        if(recipeIdentifier != null) {
-            if(!recipe.getId().equals(recipeIdentifier)) {
-                return false;
-            }
-        }
-        if(itemCondition != null) {
-            if(!itemCondition.test(recipe.craft(inventory, entity.getWorld().getRegistryManager()))) {
-                return false;
-            }
-        }
-        return true;
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+
+    public boolean doesApply(Identifier recipeId, ItemStack originalResultStack) {
+        return (recipeIdentifier == null || recipeIdentifier.equals(recipeId))
+            && (itemCondition == null || itemCondition.test(originalResultStack));
     }
 
     public void applyAfterCraftingItemAction(ItemStack output) {
-        if(lateItemAction == null) {
-            return;
+        if (itemActionAfterCrafting != null) {
+            itemActionAfterCrafting.accept(new Pair<>(entity.getWorld(), output));
         }
-        lateItemAction.accept(new Pair<>(entity.getWorld(), output));
     }
 
-    public ItemStack getNewResult(CraftingInventory inventory, CraftingRecipe recipe) {
-        ItemStack stack;
-        if(newStack != null) {
-            stack = newStack.copy();
-        } else {
-            stack = recipe.craft(inventory, entity.getWorld().getRegistryManager());
+    public ItemStack getNewResult(ItemStack originalResultStack) {
+
+        ItemStack newResultStack = newStack != null ? newStack.copy() : originalResultStack;
+        if (itemAction != null) {
+            itemAction.accept(new Pair<>(entity.getWorld(), newResultStack));
         }
-        if(itemAction != null) {
-            itemAction.accept(new Pair<>(entity.getWorld(), stack));
-        }
-        return stack;
+
+        return newResultStack;
+
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public void executeActions(Optional<BlockPos> craftingBlockPos) {
+
         if(craftingBlockPos.isPresent() && blockAction != null) {
             blockAction.accept(Triple.of(entity.getWorld(), craftingBlockPos.get(), Direction.UP));
         }
+
         if(entityAction != null) {
             entityAction.accept(entity);
         }
+
     }
 
     public static PowerFactory createFactory() {
-        return new PowerFactory<>(Apoli.identifier("modify_crafting"),
+        return new PowerFactory<>(
+            Apoli.identifier("modify_crafting"),
             new SerializableData()
                 .add("recipe", SerializableDataTypes.IDENTIFIER, null)
                 .add("item_condition", ApoliDataTypes.ITEM_CONDITION, null)
@@ -96,12 +94,20 @@ public class ModifyCraftingPower extends ValueModifyingPower {
                 .add("item_action", ApoliDataTypes.ITEM_ACTION, null)
                 .add("item_action_after_crafting", ApoliDataTypes.ITEM_ACTION, null)
                 .add("entity_action", ApoliDataTypes.ENTITY_ACTION, null)
-                .add("block_action", ApoliDataTypes.BLOCK_ACTION, null),
-            data ->
-                (type, player) -> new ModifyCraftingPower(type, player,
-                    data.getId("recipe"), data.get("item_condition"),
-                    data.get("result"), data.get("item_action"),
-                    data.get("item_action_after_crafting"), data.get("entity_action"), data.get("block_action")))
-            .allowCondition();
+                .add("block_action", ApoliDataTypes.BLOCK_ACTION, null)
+                .add("priority", SerializableDataTypes.INT, 0),
+            data -> (powerType, livingEntity) -> new ModifyCraftingPower(
+                powerType,
+                livingEntity,
+                data.getId("recipe"),
+                data.get("item_condition"),
+                data.get("result"),
+                data.get("item_action"),
+                data.get("item_action_after_crafting"),
+                data.get("entity_action"),
+                data.get("block_action"),
+                data.get("priority")
+            )
+        ).allowCondition();
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/RecipePower.java
+++ b/src/main/java/io/github/apace100/apoli/power/RecipePower.java
@@ -8,13 +8,20 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.recipe.Recipe;
 
-public class RecipePower extends Power {
+public class RecipePower extends Power implements Prioritized<RecipePower> {
 
     private final Recipe<CraftingInventory> recipe;
+    private final int priority;
 
-    public RecipePower(PowerType<?> type, LivingEntity entity, Recipe<CraftingInventory> recipe) {
+    public RecipePower(PowerType<?> type, LivingEntity entity, Recipe<CraftingInventory> recipe, int priority) {
         super(type, entity);
         this.recipe = recipe;
+        this.priority = priority;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
     }
 
     public Recipe<CraftingInventory> getRecipe() {
@@ -22,14 +29,18 @@ public class RecipePower extends Power {
     }
 
     public static PowerFactory createFactory() {
-        return new PowerFactory<>(Apoli.identifier("recipe"),
+        return new PowerFactory<>(
+            Apoli.identifier("recipe"),
             new SerializableData()
-                .add("recipe", SerializableDataTypes.RECIPE),
-            data ->
-                (type, player) -> {
-                    Recipe<CraftingInventory> recipe = (Recipe<CraftingInventory>)data.get("recipe");
-                    return new RecipePower(type, player, recipe);
-                })
-            .allowCondition();
+                .add("recipe", SerializableDataTypes.RECIPE)
+                .add("priority", SerializableDataTypes.INT, 0),
+            data -> (powerType, livingEntity) -> new RecipePower(
+                powerType,
+                livingEntity,
+                data.get("recipe"),
+                data.get("priority")
+            )
+        ).allowCondition();
     }
+
 }

--- a/src/main/java/io/github/apace100/apoli/util/ModifiedCraftingRecipe.java
+++ b/src/main/java/io/github/apace100/apoli/util/ModifiedCraftingRecipe.java
@@ -1,6 +1,5 @@
 package io.github.apace100.apoli.util;
 
-import com.google.common.collect.Lists;
 import io.github.apace100.apoli.access.PowerCraftingInventory;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.mixin.CraftingInventoryAccessor;
@@ -21,56 +20,75 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
 public class ModifiedCraftingRecipe extends SpecialCraftingRecipe {
 
-    public static final RecipeSerializer<?> SERIALIZER = new SpecialRecipeSerializer<ModifiedCraftingRecipe>(ModifiedCraftingRecipe::new);
+    public static final RecipeSerializer<?> SERIALIZER = new SpecialRecipeSerializer<>(ModifiedCraftingRecipe::new);
 
     public ModifiedCraftingRecipe(Identifier id, CraftingRecipeCategory category) {
         super(id, category);
     }
 
     @Override
-    public boolean matches(RecipeInputInventory inventory, World world)
-    {
-        if (inventory instanceof CraftingInventory craftingInventory)
-        {
-            Optional<CraftingRecipe> original = getOriginalMatch(craftingInventory);
-            if (original.isEmpty())
-            {
-                return false;
-            }
-            return getRecipes(craftingInventory).stream().anyMatch(r -> r.doesApply(craftingInventory, original.get()));
+    public boolean matches(RecipeInputInventory inventory, World world) {
+
+        if (!(inventory instanceof CraftingInventory craftingInventory)) {
+            return false;
         }
 
-        return false;
+        CraftingRecipe originalRecipe = getOriginalRecipe(craftingInventory)
+            .orElse(null);
+        if (originalRecipe == null) {
+            return false;
+        }
+
+        Identifier id = originalRecipe.getId();
+        ItemStack resultStack = originalRecipe.craft(craftingInventory, world.getRegistryManager());
+
+        return getModifyCraftingPowers(craftingInventory)
+            .stream()
+            .anyMatch(mcp -> mcp.doesApply(id, resultStack));
+
     }
 
     @Override
-    public ItemStack craft(RecipeInputInventory inventory, DynamicRegistryManager registryManager)
-    {
-        if (inventory instanceof CraftingInventory craftingInventory)
-        {
-            PlayerEntity player = getPlayerFromInventory(craftingInventory);
-            if (player != null)
-            {
-                Optional<CraftingRecipe> original = getOriginalMatch(craftingInventory);
-                if (original.isPresent())
-                {
-                    Optional<ModifyCraftingPower> optional = getRecipes(craftingInventory).stream().filter(r -> r.doesApply(craftingInventory, original.get())).findFirst();
-                    if (optional.isPresent())
-                    {
-                        ItemStack result = optional.get().getNewResult(craftingInventory, original.get());
-                        ((PowerCraftingInventory) craftingInventory).apoli$setPower(optional.get());
-                        return result;
-                    }
-                }
-            }
+    public ItemStack craft(RecipeInputInventory inventory, DynamicRegistryManager registryManager) {
+
+        ItemStack newResultStack = ItemStack.EMPTY;
+        if (!(inventory instanceof CraftingInventory craftingInventory)) {
+            return newResultStack;
         }
 
-        return ItemStack.EMPTY;
+        PlayerEntity playerEntity = getPlayerFromInventory(craftingInventory);
+        if (playerEntity == null) {
+            return newResultStack;
+        }
+
+        Optional<CraftingRecipe> originalRecipe = getOriginalRecipe(craftingInventory);
+        if (originalRecipe.isEmpty()) {
+            return newResultStack;
+        }
+
+        Identifier recipeId = originalRecipe.get().getId();
+        ItemStack resultStack = originalRecipe.get().craft(craftingInventory, registryManager);
+
+        Optional<ModifyCraftingPower> modifyCraftingPower = getModifyCraftingPowers(craftingInventory)
+            .stream()
+            .filter(mcp -> mcp.doesApply(recipeId, resultStack))
+            .max(Comparator.comparing(ModifyCraftingPower::getPriority));
+
+        if (modifyCraftingPower.isEmpty()) {
+            return resultStack;
+        }
+
+        newResultStack = modifyCraftingPower.get().getNewResult(resultStack);
+        ((PowerCraftingInventory) craftingInventory).apoli$setPower(modifyCraftingPower.get());
+
+        return newResultStack;
+
     }
 
     @Override
@@ -83,48 +101,60 @@ public class ModifiedCraftingRecipe extends SpecialCraftingRecipe {
         return SERIALIZER;
     }
 
-    public static PlayerEntity getPlayerFromInventory(CraftingInventory inv) {
-        ScreenHandler handler = ((CraftingInventoryAccessor)inv).getHandler();
+    public static PlayerEntity getPlayerFromInventory(CraftingInventory craftingInventory) {
+        ScreenHandler handler = ((CraftingInventoryAccessor) craftingInventory).getHandler();
         return getPlayerFromHandler(handler);
     }
 
-    public static Optional<BlockPos> getBlockFromInventory(CraftingInventory inv) {
-        ScreenHandler handler = ((CraftingInventoryAccessor)inv).getHandler();
-        if(handler instanceof CraftingScreenHandler) {
-            return ((CraftingScreenHandlerAccessor)handler).getContext().get((world, blockPos) -> blockPos);
+    public static Optional<BlockPos> getBlockFromInventory(CraftingInventory craftingInventory) {
+
+        ScreenHandler handler = ((CraftingInventoryAccessor) craftingInventory).getHandler();
+        if (handler instanceof CraftingScreenHandler craftingScreenHandler) {
+            return ((CraftingScreenHandlerAccessor) craftingScreenHandler).getContext().get((world, pos) -> pos);
         }
+
         return Optional.empty();
+
     }
 
-    private List<ModifyCraftingPower> getRecipes(CraftingInventory inv) {
-        ScreenHandler handler = ((CraftingInventoryAccessor)inv).getHandler();
+    private List<ModifyCraftingPower> getModifyCraftingPowers(CraftingInventory craftingInventory) {
+
+        ScreenHandler handler = ((CraftingInventoryAccessor)craftingInventory).getHandler();
         PlayerEntity player = getPlayerFromHandler(handler);
-        if(player != null) {
-            return PowerHolderComponent.getPowers(player, ModifyCraftingPower.class);
-        }
-        return Lists.newArrayList();
+
+        return PowerHolderComponent.getPowers(player, ModifyCraftingPower.class);
+
     }
 
-    private Optional<CraftingRecipe> getOriginalMatch(CraftingInventory inv) {
-        ScreenHandler handler = ((CraftingInventoryAccessor)inv).getHandler();
-        PlayerEntity player = getPlayerFromHandler(handler);
-        if(player != null && player.getServer() != null) {
-            List<CraftingRecipe> recipes = player.getServer().getRecipeManager().listAllOfType(RecipeType.CRAFTING);
-            return recipes.stream()
-                .filter(cr -> !(cr instanceof ModifiedCraftingRecipe)
-                    && cr.matches(inv, player.getWorld()))
-                .findFirst();
+    private Optional<CraftingRecipe> getOriginalRecipe(CraftingInventory craftingInventory) {
+
+        ScreenHandler screenHandler = ((CraftingInventoryAccessor) craftingInventory).getHandler();
+        PlayerEntity playerEntity = getPlayerFromHandler(screenHandler);
+
+        if (playerEntity == null || playerEntity.getServer() == null) {
+            return Optional.empty();
         }
-        return Optional.empty();
+
+        return playerEntity.getServer().getRecipeManager().listAllOfType(RecipeType.CRAFTING)
+            .stream()
+            .filter(recipe -> !(recipe instanceof ModifiedCraftingRecipe)
+                           && recipe.matches(craftingInventory, playerEntity.getWorld()))
+            .findFirst();
+
     }
 
     private static PlayerEntity getPlayerFromHandler(ScreenHandler screenHandler) {
+
         if(screenHandler instanceof CraftingScreenHandler) {
-            return ((CraftingScreenHandlerAccessor)screenHandler).getPlayer();
+            return ((CraftingScreenHandlerAccessor) screenHandler).getPlayer();
         }
+
         if(screenHandler instanceof PlayerScreenHandler) {
-            return ((PlayerScreenHandlerAccessor)screenHandler).getOwner();
+            return ((PlayerScreenHandlerAccessor) screenHandler).getOwner();
         }
+
         return null;
+
     }
+
 }

--- a/src/main/resources/apoli.mixins.json
+++ b/src/main/resources/apoli.mixins.json
@@ -30,7 +30,7 @@
 		"GrindstoneScreenHandlerOutputSlotMixin",
 		"GrindstoneScreenHandlerTopInputSlotMixin",
 		"HungerManagerMixin",
-        "ItemEntityMixin",
+		"ItemEntityMixin",
 		"ItemMixin",
 		"ItemPredicateMixin",
 		"ItemSlotArgumentTypeAccessor",
@@ -55,6 +55,7 @@
 		"ServerPlayerInteractionManagerMixin",
 		"ServerPlayNetworkHandlerMixin",
 		"ServerWorldMixin",
+		"SlotMixin",
 		"StatusEffectInstanceMixin",
 		"WeightedListEntryAccessor"
 	],


### PR DESCRIPTION
This PR fixes #121 (9/25/2023 edit: and #167) and enables the `modify_crafting` power type to modify recipes provided by the `recipe` power type. This also adds a `priority` field to both power types, where the power that has the highest value will be applied to the recipe the power either modify (`modify_crafting`) or merge (`recipe`)