### PR TITLE
Added a parent/child system to power types.

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
@@ -185,7 +185,23 @@ public class PowerTypes extends IdentifiableMultiJsonDataLoader implements Ident
                 JsonObject jsonObject = jsonElement.getAsJsonObject();
                 PrePowerLoadCallback.EVENT.invoker().onPrePowerLoad(fileId, jsonObject);
 
+                if(JsonHelper.hasString(jsonObject, "parent")) {
+                    Identifier parentId = new Identifier(JsonHelper.getString(jsonObject, "parent"));
+                    if(multiJsonDataContainer.get(parentId) != null) {
+                        for (JsonElement element : multiJsonDataContainer.get(parentId)) {
+                            for (Map.Entry<String, JsonElement> stringJsonElementEntry : element.getAsJsonObject().entrySet()) {
+                                if (!jsonObject.has(stringJsonElementEntry.getKey())) {
+                                    jsonObject.add(stringJsonElementEntry.getKey(), stringJsonElementEntry.getValue());
+                                }
+                            }
+                        }
+                    } else {
+                        Apoli.LOGGER.warn("\"parent\" field contains invalid power id: \"" + parentId + "\". Is this power registered?");
+                    }
+                }
+
                 Identifier powerFactoryId = new Identifier(JsonHelper.getString(jsonObject, "type"));
+
 
                 if (!isMultiple(powerFactoryId)) {
                     readPower(packName, fileId, jsonObject);

--- a/src/test/resources/data/apoli/powers/parent_example.json
+++ b/src/test/resources/data/apoli/powers/parent_example.json
@@ -1,0 +1,10 @@
+{
+	"parent": "apoli:black_on_soul_sand",
+	"condition": {
+		"type": "apoli:on_block",
+		"block_condition": {
+			"type": "apoli:block",
+			"block": "minecraft:sand"
+		}
+	}
+}


### PR DESCRIPTION
adds an optional "parent" field to power types that accepts a power id. the JsonObjects of the powers, will then be merged. with the child's fields taking priority over the parents, allowing for overriding actions or conditions.

NOTE: You cannot make a child of a child, because the parent field will never be overwriten by that of a child. so the sub-child will never have a reference to the original.