### PR TITLE
Add `modify_fov` power type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/AbstractClientPlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/AbstractClientPlayerEntityMixin.java
@@ -1,0 +1,50 @@
+package io.github.apace100.apoli.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.authlib.GameProfile;
+import io.github.apace100.apoli.component.PowerHolderComponent;
+import io.github.apace100.apoli.power.ModifyFovPower;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.List;
+
+@Mixin(AbstractClientPlayerEntity.class)
+public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity {
+
+    private AbstractClientPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
+        super(world, pos, yaw, gameProfile);
+    }
+
+    @ModifyExpressionValue(method = "getFovMultiplier", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;isUsingSpyglass()Z"))
+    private boolean apoli$delegateSpyglassFovMultiplier(boolean original) {
+        return !PowerHolderComponent.hasPower(this, ModifyFovPower.class) && original;
+    }
+
+    @WrapOperation(method = "getFovMultiplier", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;lerp(FFF)F"))
+    private float apoli$modifyFov(float delta, float start, float end, Operation<Float> original) {
+
+        List<ModifyFovPower> mfps = PowerHolderComponent.getPowers(this, ModifyFovPower.class);
+        if (mfps.isEmpty()) {
+            return original.call(delta, start, end);
+        }
+
+        boolean affectedByFovEffectScale = mfps
+            .stream()
+            .anyMatch(ModifyFovPower::isAffectedByFovEffectScale);
+
+        float newEnd = PowerHolderComponent.modify(this, ModifyFovPower.class, end);
+        float newDelta = affectedByFovEffectScale ? delta : start;
+
+        return MathHelper.lerp(newDelta, start, newEnd);
+
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/mixin/AbstractClientPlayerEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/AbstractClientPlayerEntityMixin.java
@@ -1,6 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.authlib.GameProfile;
@@ -9,7 +9,6 @@ import io.github.apace100.apoli.power.ModifyFovPower;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,27 +22,23 @@ public abstract class AbstractClientPlayerEntityMixin extends PlayerEntity {
         super(world, pos, yaw, gameProfile);
     }
 
-    @ModifyExpressionValue(method = "getFovMultiplier", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;isUsingSpyglass()Z"))
-    private boolean apoli$delegateSpyglassFovMultiplier(boolean original) {
-        return !PowerHolderComponent.hasPower(this, ModifyFovPower.class) && original;
+    @ModifyReturnValue(method = "getFovMultiplier", at = @At(value = "RETURN", ordinal = 0))
+    private float apoli$modifySpyglassFov(float original) {
+        return PowerHolderComponent.modify(this, ModifyFovPower.class, original);
     }
 
     @WrapOperation(method = "getFovMultiplier", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;lerp(FFF)F"))
     private float apoli$modifyFov(float delta, float start, float end, Operation<Float> original) {
 
         List<ModifyFovPower> mfps = PowerHolderComponent.getPowers(this, ModifyFovPower.class);
-        if (mfps.isEmpty()) {
-            return original.call(delta, start, end);
-        }
-
-        boolean affectedByFovEffectScale = mfps
+        boolean affectedByFovEffectScale = mfps.isEmpty() || mfps
             .stream()
             .anyMatch(ModifyFovPower::isAffectedByFovEffectScale);
 
         float newEnd = PowerHolderComponent.modify(this, ModifyFovPower.class, end);
         float newDelta = affectedByFovEffectScale ? delta : start;
 
-        return MathHelper.lerp(newDelta, start, newEnd);
+        return original.call(newDelta, start, newEnd);
 
     }
 

--- a/src/main/java/io/github/apace100/apoli/power/ModifyFovPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ModifyFovPower.java
@@ -1,0 +1,51 @@
+package io.github.apace100.apoli.power;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.util.modifier.Modifier;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.LivingEntity;
+
+import java.util.List;
+
+public class ModifyFovPower extends ValueModifyingPower {
+
+    private final boolean affectedByFovEffectScale;
+
+    public ModifyFovPower(PowerType<?> type, LivingEntity entity, Modifier modifier, List<Modifier> modifiers, boolean affectedByFovEffectScale) {
+        super(type, entity);
+        this.affectedByFovEffectScale = affectedByFovEffectScale;
+
+        if (modifier != null) {
+            this.addModifier(modifier);
+        }
+
+        if (modifiers != null) {
+            modifiers.forEach(this::addModifier);
+        }
+
+    }
+
+    public boolean isAffectedByFovEffectScale() {
+        return affectedByFovEffectScale;
+    }
+
+    public static PowerFactory createFactory() {
+        return new PowerFactory<>(
+            Apoli.identifier("modify_fov"),
+            new SerializableData()
+                .add("modifier", Modifier.DATA_TYPE, null)
+                .add("modifiers", Modifier.LIST_TYPE, null)
+                .add("affected_by_fov_effect_scale", SerializableDataTypes.BOOLEAN, true),
+            data -> (powerType, entity) -> new ModifyFovPower(
+                powerType,
+                entity,
+                data.get("modifier"),
+                data.get("modifiers"),
+                data.get("affected_by_fov_effect_scale")
+            )
+        ).allowCondition();
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -131,6 +131,7 @@ public class PowerFactories {
         register(ActionOnBlockPlacePower::createFactory);
         register(PreventBlockPlacePower::createFactory);
         register(EntitySetPower::createFactory);
+        register(ModifyFovPower::createFactory);
     }
 
     private static void register(PowerFactory<?> powerFactory) {

--- a/src/main/resources/apoli.mixins.json
+++ b/src/main/resources/apoli.mixins.json
@@ -69,6 +69,7 @@
         "WeightedListEntryAccessor"
     ],
     "client": [
+        "AbstractClientPlayerEntityMixin",
         "BackgroundRendererMixin",
         "CapeFeatureRendererMixin",
         "ChunkRendererRegionMixin",


### PR DESCRIPTION
This PR adds [eggolib's `modify_fov` power type](https://eggolib.github.io/latest/types/power_types/modify_fov), which modifies the FOV multiplier of the player; optionally, can ignore the player's FOV effects option. Resolves #196 