### PR TITLE
Make the `*_block_use` power types consistent with the `*_entity_use` power types

### DIFF
--- a/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
+++ b/src/main/java/io/github/apace100/apoli/data/ApoliDataTypes.java
@@ -440,6 +440,10 @@ public class ApoliDataTypes {
         }
     );
 
+    public static final SerializableDataType<BlockUsagePhase> BLOCK_USAGE_PHASE = SerializableDataType.enumValue(BlockUsagePhase.class);
+
+    public static final SerializableDataType<EnumSet<BlockUsagePhase>> BLOCK_USAGE_PHASE_SET = SerializableDataType.enumSet(BlockUsagePhase.class, BLOCK_USAGE_PHASE);
+
     public static <T> SerializableDataType<ConditionFactory<T>.Instance> condition(Registry<ConditionFactory<T>> registry, String name) {
         return condition(registry, IdentifierAlias.GLOBAL, name);
     }

--- a/src/main/java/io/github/apace100/apoli/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ClientPlayerInteractionManagerMixin.java
@@ -1,48 +1,259 @@
 package io.github.apace100.apoli.mixin;
 
-import io.github.apace100.apoli.component.PowerHolderComponent;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import io.github.apace100.apoli.power.ActionOnBlockUsePower;
+import io.github.apace100.apoli.power.ActiveInteractionPower;
 import io.github.apace100.apoli.power.PreventBlockUsePower;
+import io.github.apace100.apoli.power.Prioritized;
+import io.github.apace100.apoli.util.ActionResultUtil;
+import io.github.apace100.apoli.util.BlockUsagePhase;
+import io.github.apace100.apoli.util.PriorityPhase;
+import net.minecraft.block.BlockState;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemUsageContext;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import java.util.List;
 
 @Mixin(ClientPlayerInteractionManager.class)
 public abstract class ClientPlayerInteractionManagerMixin {
 
-    @Inject(method = "interactBlockInternal", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;shouldCancelInteraction()Z"), cancellable = true)
-    private void apoli$preventBlockInteraction(ClientPlayerEntity player, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
-        if(PowerHolderComponent.hasPower(player, PreventBlockUsePower.class, pbup -> pbup.doesPrevent(player.getWorld(), hitResult.getBlockPos()))) {
-            cir.setReturnValue(ActionResult.PASS);
+    @WrapOperation(method = "interactBlockInternal", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;onUse(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;"))
+    private ActionResult apoli$beforeUseBlock(BlockState state, World world, PlayerEntity player, Hand hand, BlockHitResult hitResult, Operation<ActionResult> original, @Share("zeroPriority$onBlock") LocalRef<ActionResult> zeroPriority$onBlockRef, @Share("zeroPriority$itemOnBlock") LocalRef<ActionResult> zeroPriority$itemOnBlockRef) {
+
+        ItemStack stackInHand = player.getStackInHand(hand);
+        BlockUsagePhase usePhase = BlockUsagePhase.BLOCK;
+
+        zeroPriority$onBlockRef.set(ActionResult.PASS);
+        zeroPriority$itemOnBlockRef.set(ActionResult.PASS);
+
+        if (PreventBlockUsePower.doesPrevent(player, usePhase, hitResult, stackInHand, hand)) {
+            return ActionResult.FAIL;
         }
-    }
 
-    @Inject(method = "interactBlockInternal", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;shouldCancelInteraction()Z"), cancellable = true)
-    private void apoli$executeBlockUseActions(ClientPlayerEntity player, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
+        Prioritized.CallInstance<ActiveInteractionPower> aipci = new Prioritized.CallInstance<>();
+        aipci.add(player, ActionOnBlockUsePower.class, p -> p.shouldExecute(usePhase, PriorityPhase.BEFORE, hitResult, hand, stackInHand));
 
-        ActionResult result = ActionResult.PASS;
-        for (ActionOnBlockUsePower aobup : PowerHolderComponent.getPowers(player, ActionOnBlockUsePower.class)) {
+        for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
 
-            if (!aobup.shouldExecute(hitResult, hand, player.getStackInHand(hand))) {
+            if (!aipci.hasPowers(i)) {
                 continue;
             }
 
-            ActionResult newResult = aobup.executeAction(hitResult, hand);
-            if ((newResult.isAccepted() && !result.isAccepted()) || (newResult.shouldSwingHand() && !result.shouldSwingHand())) {
-                result = newResult;
+            List<ActiveInteractionPower> aips = aipci.getPowers(i);
+            ActionResult previousResult = ActionResult.PASS;
+
+            for (ActiveInteractionPower aip : aips) {
+
+                ActionResult currentResult = aip instanceof ActionOnBlockUsePower aobup
+                    ? aobup.executeAction(hitResult, hand)
+                    : ActionResult.PASS;
+
+                if (ActionResultUtil.shouldOverride(previousResult, currentResult)) {
+                    previousResult = currentResult;
+                }
+
+            }
+
+            if (i == 0) {
+                zeroPriority$onBlockRef.set(previousResult);
+                continue;
+            }
+
+            if (previousResult == ActionResult.PASS) {
+                continue;
+            }
+
+            if (previousResult.shouldSwingHand()) {
+                player.swingHand(hand);
+            }
+
+            return previousResult;
+
+        }
+
+        return original.call(state, world, player, hand, hitResult);
+
+    }
+
+    @ModifyReturnValue(method = "interactBlockInternal", at = @At(value = "RETURN", ordinal = 0), slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/util/ActionResult;isAccepted()Z")))
+    private ActionResult apoli$afterUseBlock(ActionResult original, ClientPlayerEntity player, Hand hand, BlockHitResult hitResult, @Share("zeroPriority$onBlock") LocalRef<ActionResult> zeroPriority$onBlockRef) {
+
+        ItemStack stackInHand = player.getStackInHand(hand);
+
+        ActionResult zeroPriority$onBlock = zeroPriority$onBlockRef.get();
+        ActionResult newResult = ActionResult.PASS;
+
+        if (zeroPriority$onBlock != ActionResult.PASS) {
+            newResult = zeroPriority$onBlock;
+        }
+
+        else if (original == ActionResult.PASS) {
+
+            Prioritized.CallInstance<ActiveInteractionPower> aipci = new Prioritized.CallInstance<>();
+            aipci.add(player, ActionOnBlockUsePower.class, p -> p.shouldExecute(BlockUsagePhase.BLOCK, PriorityPhase.AFTER, hitResult, hand, stackInHand));
+
+            for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
+
+                if (!aipci.hasPowers(i)) {
+                    continue;
+                }
+
+                List<ActiveInteractionPower> aips = aipci.getPowers(i);
+                ActionResult previousResult = ActionResult.PASS;
+
+                for (ActiveInteractionPower aip : aips) {
+
+                    ActionResult currentResult = aip instanceof ActionOnBlockUsePower aobup
+                        ? aobup.executeAction(hitResult, hand)
+                        : ActionResult.PASS;
+
+                    if (ActionResultUtil.shouldOverride(previousResult, currentResult)) {
+                        previousResult = currentResult;
+                    }
+
+                }
+
+                if (previousResult != ActionResult.PASS) {
+                    newResult = previousResult;
+                    break;
+                }
+
             }
 
         }
 
-        if (result.isAccepted()) {
-            cir.setReturnValue(result);
+        if (newResult.shouldSwingHand()) {
+            player.swingHand(hand, true);
         }
+
+        return ActionResultUtil.shouldOverride(original, newResult)
+            ? newResult
+            : original;
+
+    }
+
+    @WrapOperation(method = "interactBlockInternal", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;useOnBlock(Lnet/minecraft/item/ItemUsageContext;)Lnet/minecraft/util/ActionResult;"))
+    private ActionResult apoli$beforeItemUseOnBlock(ItemStack stack, ItemUsageContext context, Operation<ActionResult> original, ClientPlayerEntity player, Hand hand, BlockHitResult hitResult, @Share("zeroPriority$itemOnBlock") LocalRef<ActionResult> zeroPriority$itemOnBlockRef) {
+
+        ItemStack stackInHand = player.getStackInHand(hand);
+        BlockUsagePhase usePhase = BlockUsagePhase.ITEM;
+
+        zeroPriority$itemOnBlockRef.set(ActionResult.PASS);
+        if (PreventBlockUsePower.doesPrevent(player, usePhase, hitResult, stackInHand, hand)) {
+            return ActionResult.FAIL;
+        }
+
+        Prioritized.CallInstance<ActiveInteractionPower> aipci = new Prioritized.CallInstance<>();
+        aipci.add(player, ActionOnBlockUsePower.class, p -> p.shouldExecute(usePhase, PriorityPhase.BEFORE, hitResult, hand, stackInHand));
+
+        for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
+
+            if (!aipci.hasPowers(i)) {
+                continue;
+            }
+
+            List<ActiveInteractionPower> aips = aipci.getPowers(i);
+            ActionResult previousResult = ActionResult.PASS;
+
+            for (ActiveInteractionPower aip : aips) {
+
+                ActionResult currentResult = aip instanceof ActionOnBlockUsePower aobup
+                    ? aobup.executeAction(hitResult, hand)
+                    : ActionResult.PASS;
+
+                if (ActionResultUtil.shouldOverride(previousResult, currentResult)) {
+                    previousResult = currentResult;
+                }
+
+            }
+
+            if (i == 0) {
+                zeroPriority$itemOnBlockRef.set(previousResult);
+                continue;
+            }
+
+            if (previousResult == ActionResult.PASS) {
+                continue;
+            }
+
+            if (previousResult.shouldSwingHand()) {
+                player.swingHand(hand);
+            }
+
+            return previousResult;
+
+        }
+
+        return original.call(stack, context);
+
+    }
+
+    @ModifyReturnValue(method = "interactBlockInternal", at = @At("RETURN"), slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;getItemCooldownManager()Lnet/minecraft/entity/player/ItemCooldownManager;")))
+    private ActionResult apoli$afterItemUseOnBlock(ActionResult original, ClientPlayerEntity player, Hand hand, BlockHitResult hitResult, @Share("zeroPriority$itemOnBlock") LocalRef<ActionResult> zeroPriority$itemOnBlockRef) {
+
+        ActionResult zeroPriority$itemOnBlock = zeroPriority$itemOnBlockRef.get();
+        ActionResult newResult = ActionResult.PASS;
+
+        if (zeroPriority$itemOnBlock != ActionResult.PASS) {
+            newResult = zeroPriority$itemOnBlock;
+        }
+
+        else if (original == ActionResult.PASS) {
+
+            Prioritized.CallInstance<ActiveInteractionPower> aipci = new Prioritized.CallInstance<>();
+            aipci.add(player, ActionOnBlockUsePower.class, p -> p.shouldExecute(BlockUsagePhase.ITEM, PriorityPhase.AFTER, hitResult, hand, player.getStackInHand(hand)));
+
+            for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
+
+                if (!aipci.hasPowers(i)) {
+                    continue;
+                }
+
+                List<ActiveInteractionPower> aips = aipci.getPowers(i);
+                ActionResult previousResult = ActionResult.PASS;
+
+                for (ActiveInteractionPower aip : aips) {
+
+                    ActionResult currentResult = aip instanceof ActionOnBlockUsePower aobup
+                        ? aobup.executeAction(hitResult, hand)
+                        : ActionResult.PASS;
+
+                    if (ActionResultUtil.shouldOverride(previousResult, currentResult)) {
+                        previousResult = currentResult;
+                    }
+
+                }
+
+                if (previousResult != ActionResult.PASS) {
+                    newResult = previousResult;
+                    break;
+                }
+
+            }
+
+        }
+
+        if (newResult.shouldSwingHand()) {
+            player.swingHand(hand);
+        }
+
+        return ActionResultUtil.shouldOverride(original, newResult)
+            ? newResult
+            : original;
 
     }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ItemStackMixin.java
@@ -22,9 +22,7 @@ import net.minecraft.inventory.StackReference;
 import net.minecraft.item.FoodComponent;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemUsageContext;
 import net.minecraft.sound.SoundEvent;
-import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.UseAction;
@@ -342,21 +340,6 @@ public abstract class ItemStackMixin implements EntityLinkedItemStack, Potential
 
         user.setCurrentHand(hand);
         return TypedActionResult.consume(stackInHand);
-
-    }
-
-    @WrapOperation(method = "useOnBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/Item;useOnBlock(Lnet/minecraft/item/ItemUsageContext;)Lnet/minecraft/util/ActionResult;"))
-    private ActionResult apoli$consumeUsableOnBlockCustomFood(Item instance, ItemUsageContext context, Operation<ActionResult> original) {
-
-        PlayerEntity user = context.getPlayer();
-        EdibleItemPower edibleItemPower = this.apoli$getEdiblePower().orElse(null);
-
-        if (user == null || edibleItemPower == null || !user.canConsume(edibleItemPower.getFoodComponent().isAlwaysEdible())) {
-            return original.call(instance, context);
-        }
-
-        user.setCurrentHand(context.getHand());
-        return ActionResult.CONSUME_PARTIAL;
 
     }
 

--- a/src/main/java/io/github/apace100/apoli/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/ServerPlayerInteractionManagerMixin.java
@@ -1,17 +1,23 @@
 package io.github.apace100.apoli.mixin;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import io.github.apace100.apoli.component.PowerHolderComponent;
-import io.github.apace100.apoli.power.ActionOnBlockBreakPower;
-import io.github.apace100.apoli.power.ActionOnBlockUsePower;
-import io.github.apace100.apoli.power.ModifyHarvestPower;
-import io.github.apace100.apoli.power.PreventBlockUsePower;
+import io.github.apace100.apoli.power.*;
+import io.github.apace100.apoli.util.ActionResultUtil;
+import io.github.apace100.apoli.util.BlockUsagePhase;
+import io.github.apace100.apoli.util.PriorityPhase;
 import io.github.apace100.apoli.util.SavedBlockPosition;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemUsageContext;
 import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.network.ServerPlayerInteractionManager;
@@ -28,8 +34,11 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
 
 @Mixin(ServerPlayerInteractionManager.class)
 public class ServerPlayerInteractionManagerMixin {
@@ -78,18 +87,227 @@ public class ServerPlayerInteractionManagerMixin {
             aobbp -> aobbp.executeActions(harvestedSuccessfully, pos, apoli$blockBreakDirection));
     }
 
-    @Inject(method = "interactBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;shouldCancelInteraction()Z"), cancellable = true)
-    private void apoli$preventBlockInteraction(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
-        if (PowerHolderComponent.hasPower(player, PreventBlockUsePower.class, pbup -> pbup.doesPrevent(world, hitResult.getBlockPos()))) {
-            cir.setReturnValue(ActionResult.FAIL);
+    @WrapOperation(method = "interactBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;onUse(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;"))
+    private ActionResult apoli$beforeUseBlock(BlockState state, World world, PlayerEntity player, Hand hand, BlockHitResult hitResult, Operation<ActionResult> original, @Share("zeroPriority$onBlock") LocalRef<ActionResult> zeroPriority$onBlockRef, @Share("zeroPriority$itemOnBlock") LocalRef<ActionResult> zeroPriority$itemOnBlockRef) {
+
+        ItemStack stackInHand = player.getStackInHand(hand);
+        BlockUsagePhase usePhase = BlockUsagePhase.BLOCK;
+
+        zeroPriority$onBlockRef.set(ActionResult.PASS);
+        zeroPriority$itemOnBlockRef.set(ActionResult.PASS);
+
+        if (PreventBlockUsePower.doesPrevent(player, usePhase, hitResult, stackInHand, hand)) {
+            return ActionResult.FAIL;
         }
+
+        Prioritized.CallInstance<ActiveInteractionPower> aipci = new Prioritized.CallInstance<>();
+        aipci.add(player, ActionOnBlockUsePower.class, p -> p.shouldExecute(usePhase, PriorityPhase.BEFORE, hitResult, hand, stackInHand));
+
+        for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
+
+            if (!aipci.hasPowers(i)) {
+                continue;
+            }
+
+            List<ActiveInteractionPower> aips = aipci.getPowers(i);
+            ActionResult previousResult = ActionResult.PASS;
+
+            for (ActiveInteractionPower aip : aips) {
+
+                ActionResult currentResult = aip instanceof ActionOnBlockUsePower aobup
+                    ? aobup.executeAction(hitResult, hand)
+                    : ActionResult.PASS;
+
+                if (ActionResultUtil.shouldOverride(previousResult, currentResult)) {
+                    previousResult = currentResult;
+                }
+
+            }
+
+            if (i == 0) {
+                zeroPriority$onBlockRef.set(previousResult);
+                continue;
+            }
+
+            if (previousResult == ActionResult.PASS) {
+                continue;
+            }
+
+            if (previousResult.shouldSwingHand()) {
+                player.swingHand(hand);
+            }
+
+            return previousResult;
+
+        }
+
+        return original.call(state, world, player, hand, hitResult);
+
     }
 
-    @Inject(method = "interactBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;copy()Lnet/minecraft/item/ItemStack;"))
-    private void apoli$executeBlockUseActions(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, CallbackInfoReturnable<ActionResult> cir) {
-        PowerHolderComponent.withPowers(this.player, ActionOnBlockUsePower.class,
-            aobbp -> aobbp.shouldExecute(hitResult, hand, stack),
-            aobbp -> aobbp.executeAction(hitResult, hand));
+    @ModifyReturnValue(method = "interactBlock", at = @At(value = "RETURN", ordinal = 0), slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;getMainHandStack()Lnet/minecraft/item/ItemStack;")))
+    private ActionResult apoli$afterUseBlock(ActionResult original, ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, @Share("zeroPriority$onBlock") LocalRef<ActionResult> zeroPriority$onBlockRef) {
+
+        ActionResult zeroPriority$onBlock = zeroPriority$onBlockRef.get();
+        ActionResult newResult = ActionResult.PASS;
+
+        if (zeroPriority$onBlock != ActionResult.PASS) {
+            newResult = zeroPriority$onBlock;
+        }
+
+        else if (original == ActionResult.PASS) {
+
+            Prioritized.CallInstance<ActiveInteractionPower> aipci = new Prioritized.CallInstance<>();
+            aipci.add(player, ActionOnBlockUsePower.class, p -> p.shouldExecute(BlockUsagePhase.BLOCK, PriorityPhase.AFTER, hitResult, hand, stack));
+
+            for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
+
+                if (!aipci.hasPowers(i)) {
+                    continue;
+                }
+
+                List<ActiveInteractionPower> aips = aipci.getPowers(i);
+                ActionResult previousResult = ActionResult.PASS;
+
+                for (ActiveInteractionPower aip : aips) {
+
+                    ActionResult currentResult = aip instanceof ActionOnBlockUsePower aobup
+                        ? aobup.executeAction(hitResult, hand)
+                        : ActionResult.PASS;
+
+                    if (ActionResultUtil.shouldOverride(previousResult, currentResult)) {
+                        previousResult = currentResult;
+                    }
+
+                }
+
+                if (previousResult != ActionResult.PASS) {
+                    newResult = previousResult;
+                    break;
+                }
+
+            }
+
+        }
+
+        if (newResult.shouldSwingHand()) {
+            player.swingHand(hand, true);
+        }
+
+        return ActionResultUtil.shouldOverride(original, newResult)
+            ? newResult
+            : original;
+
+    }
+
+    @WrapOperation(method = "interactBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;useOnBlock(Lnet/minecraft/item/ItemUsageContext;)Lnet/minecraft/util/ActionResult;"))
+    private ActionResult apoli$beforeItemUseOnBlock(ItemStack stack, ItemUsageContext context, Operation<ActionResult> original, ServerPlayerEntity mPlayer, World mWorld, ItemStack mStack, Hand mHand, BlockHitResult mHitResult, @Share("zeroPriority$itemOnBlock") LocalRef<ActionResult> zeroPriority$itemOnBlockRef) {
+
+        BlockUsagePhase usePhase = BlockUsagePhase.ITEM;
+        zeroPriority$itemOnBlockRef.set(ActionResult.PASS);
+
+        if (PreventBlockUsePower.doesPrevent(player, usePhase, mHitResult, mStack, mHand)) {
+            return ActionResult.FAIL;
+        }
+
+        Prioritized.CallInstance<ActiveInteractionPower> aipci = new Prioritized.CallInstance<>();
+        aipci.add(player, ActionOnBlockUsePower.class, p -> p.shouldExecute(usePhase, PriorityPhase.BEFORE, mHitResult, mHand, mStack));
+
+        for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
+
+            if (!aipci.hasPowers(i)) {
+                continue;
+            }
+
+            List<ActiveInteractionPower> aips = aipci.getPowers(i);
+            ActionResult previousResult = ActionResult.PASS;
+
+            for (ActiveInteractionPower aip : aips) {
+
+                ActionResult currentResult = aip instanceof ActionOnBlockUsePower aobup
+                    ? aobup.executeAction(mHitResult, mHand)
+                    : ActionResult.PASS;
+
+                if (ActionResultUtil.shouldOverride(previousResult, currentResult)) {
+                    previousResult = currentResult;
+                }
+
+            }
+
+            if (i == 0) {
+                zeroPriority$itemOnBlockRef.set(previousResult);
+                continue;
+            }
+
+            if (previousResult == ActionResult.PASS) {
+                continue;
+            }
+
+            if (previousResult.shouldSwingHand()) {
+                player.swingHand(mHand, true);
+            }
+
+            return previousResult;
+
+        }
+
+        return original.call(stack, context);
+
+    }
+
+    @ModifyReturnValue(method = "interactBlock", at = @At("RETURN"), slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;getItemCooldownManager()Lnet/minecraft/entity/player/ItemCooldownManager;")))
+    private ActionResult apoli$afterItemUseOnBlock(ActionResult original, ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockHitResult hitResult, @Share("zeroPriority$itemOnBlock") LocalRef<ActionResult> zeroPriority$itemOnBlockRef) {
+
+        ActionResult zeroPriority$itemOnBlock = zeroPriority$itemOnBlockRef.get();
+        ActionResult newResult = ActionResult.PASS;
+
+        if (zeroPriority$itemOnBlock != ActionResult.PASS) {
+            newResult = zeroPriority$itemOnBlock;
+        }
+
+        else if (original == ActionResult.PASS) {
+
+            Prioritized.CallInstance<ActiveInteractionPower> aipci = new Prioritized.CallInstance<>();
+            aipci.add(player, ActionOnBlockUsePower.class, p -> p.shouldExecute(BlockUsagePhase.ITEM, PriorityPhase.AFTER, hitResult, hand, stack));
+
+            for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
+
+                if (!aipci.hasPowers(i)) {
+                    continue;
+                }
+
+                List<ActiveInteractionPower> aips = aipci.getPowers(i);
+                ActionResult previousResult = ActionResult.PASS;
+
+                for (ActiveInteractionPower aip : aips) {
+
+                    ActionResult currentResult = aip instanceof ActionOnBlockUsePower aobup
+                        ? aobup.executeAction(hitResult, hand)
+                        : ActionResult.PASS;
+
+                    if (ActionResultUtil.shouldOverride(previousResult, currentResult)) {
+                        previousResult = currentResult;
+                    }
+
+                }
+
+                if (previousResult != ActionResult.PASS) {
+                    newResult = previousResult;
+                    break;
+                }
+
+            }
+
+        }
+
+        if (newResult.shouldSwingHand()) {
+            player.swingHand(hand);
+        }
+
+        return ActionResultUtil.shouldOverride(original, newResult)
+            ? newResult
+            : original;
+
     }
 
 }

--- a/src/main/java/io/github/apace100/apoli/power/ActionOnBlockUsePower.java
+++ b/src/main/java/io/github/apace100/apoli/power/ActionOnBlockUsePower.java
@@ -3,6 +3,8 @@ package io.github.apace100.apoli.power;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.util.BlockUsagePhase;
+import io.github.apace100.apoli.util.PriorityPhase;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.block.pattern.CachedBlockPosition;
@@ -30,34 +32,42 @@ public class ActionOnBlockUsePower extends ActiveInteractionPower {
     private final Consumer<Triple<World, BlockPos, Direction>> blockAction;
 
     private final Predicate<CachedBlockPosition> blockCondition;
-    private final EnumSet<Direction> directions;
 
-    public ActionOnBlockUsePower(PowerType<?> type, LivingEntity entity, EnumSet<Hand> hands, ActionResult actionResult, Predicate<Pair<World, ItemStack>> itemCondition, Consumer<Pair<World, StackReference>> heldItemAction, ItemStack itemResult, Consumer<Pair<World, StackReference>> resultItemAction, Consumer<Entity> entityAction, Predicate<CachedBlockPosition> blockCondition, EnumSet<Direction> directions, Consumer<Triple<World, BlockPos, Direction>> blockAction, int priority) {
+    private final EnumSet<Direction> directions;
+    private final EnumSet<BlockUsagePhase> usePhases;
+
+    public ActionOnBlockUsePower(PowerType<?> type, LivingEntity entity, Consumer<Entity> entityAction, Consumer<Triple<World, BlockPos, Direction>> blockAction, Consumer<Pair<World, StackReference>> heldItemAction, Consumer<Pair<World, StackReference>> resultItemAction, Predicate<CachedBlockPosition> blockCondition, Predicate<Pair<World, ItemStack>> itemCondition, ItemStack itemResult, EnumSet<Direction> directions, EnumSet<Hand> hands, EnumSet<BlockUsagePhase> usePhases, ActionResult actionResult, int priority) {
         super(type, entity, hands, actionResult, itemCondition, heldItemAction, itemResult, resultItemAction, priority);
         this.entityAction = entityAction;
         this.blockCondition = blockCondition;
         this.directions = directions;
         this.blockAction = blockAction;
+        this.usePhases = usePhases;
     }
 
-    public boolean shouldExecute(BlockHitResult hitResult, Hand hand, ItemStack heldStack) {
+    public boolean shouldExecute(BlockUsagePhase usePhase, PriorityPhase priorityPhase, BlockHitResult hitResult, Hand hand, ItemStack heldStack) {
         return super.shouldExecute(hand, heldStack)
+            && priorityPhase.test(this.getPriority())
+            && usePhases.contains(usePhase)
             && directions.contains(hitResult.getSide())
             && (blockCondition == null || blockCondition.test(new CachedBlockPosition(entity.getWorld(), hitResult.getBlockPos(), true)));
     }
 
     public ActionResult executeAction(BlockHitResult hitResult, Hand hand) {
 
-        if(blockAction != null) {
-            blockAction.accept(Triple.of(entity.getWorld(), hitResult.getBlockPos(), hitResult.getSide()));
+        if (blockAction != null) {
+            this.blockAction.accept(Triple.of(entity.getWorld(), hitResult.getBlockPos(), hitResult.getSide()));
         }
 
-        if(entityAction != null) {
-            entityAction.accept(entity);
+        if (entityAction != null) {
+            this.entityAction.accept(entity);
         }
 
-        performActorItemStuff(this, (PlayerEntity) entity, hand);
-        return getActionResult();
+        if (entity instanceof PlayerEntity player) {
+            this.performActorItemStuff(this, player, hand);
+        }
+
+        return this.getActionResult();
 
     }
 
@@ -65,31 +75,34 @@ public class ActionOnBlockUsePower extends ActiveInteractionPower {
         return new PowerFactory<>(
             Apoli.identifier("action_on_block_use"),
             new SerializableData()
-                .add("block_condition", ApoliDataTypes.BLOCK_CONDITION, null)
                 .add("entity_action", ApoliDataTypes.ENTITY_ACTION, null)
                 .add("block_action", ApoliDataTypes.BLOCK_ACTION, null)
-                .add("directions", SerializableDataTypes.DIRECTION_SET, EnumSet.allOf(Direction.class))
-                .add("item_condition", ApoliDataTypes.ITEM_CONDITION, null)
-                .add("hands", SerializableDataTypes.HAND_SET, EnumSet.allOf(Hand.class))
-                .add("result_stack", SerializableDataTypes.ITEM_STACK, null)
                 .add("held_item_action", ApoliDataTypes.ITEM_ACTION, null)
                 .add("result_item_action", ApoliDataTypes.ITEM_ACTION, null)
+                .add("block_condition", ApoliDataTypes.BLOCK_CONDITION, null)
+                .add("item_condition", ApoliDataTypes.ITEM_CONDITION, null)
+                .add("result_stack", SerializableDataTypes.ITEM_STACK, null)
+                .add("directions", SerializableDataTypes.DIRECTION_SET, EnumSet.allOf(Direction.class))
+                .add("hands", SerializableDataTypes.HAND_SET, EnumSet.allOf(Hand.class))
+                .add("usage_phases", ApoliDataTypes.BLOCK_USAGE_PHASE_SET, EnumSet.allOf(BlockUsagePhase.class))
                 .add("action_result", SerializableDataTypes.ACTION_RESULT, ActionResult.SUCCESS)
                 .add("priority", SerializableDataTypes.INT, 0),
             data -> (powerType, livingEntity) -> new ActionOnBlockUsePower(
                 powerType,
                 livingEntity,
-                data.get("hands"),
-                data.get("action_result"),
-                data.get("item_condition"),
-                data.get("held_item_action"),
-                data.get("result_stack"),
-                data.get("result_item_action"),
                 data.get("entity_action"),
-                data.get("block_condition"),
-                data.get("directions"),
                 data.get("block_action"),
-                data.get("priority"))
+                data.get("held_item_action"),
+                data.get("result_item_action"),
+                data.get("block_condition"),
+                data.get("item_condition"),
+                data.get("result_stack"),
+                data.get("directions"),
+                data.get("hands"),
+                data.get("usage_phases"),
+                data.get("action_result"),
+                data.get("priority")
+            )
         ).allowCondition();
     }
 }

--- a/src/main/java/io/github/apace100/apoli/power/PreventBlockUsePower.java
+++ b/src/main/java/io/github/apace100/apoli/power/PreventBlockUsePower.java
@@ -3,36 +3,112 @@ package io.github.apace100.apoli.power;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.apoli.util.BlockUsagePhase;
 import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.block.pattern.CachedBlockPosition;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.StackReference;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.Pair;
+import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.WorldView;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import org.apache.commons.lang3.tuple.Triple;
 
+import java.util.EnumSet;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-public class PreventBlockUsePower extends Power {
+public class PreventBlockUsePower extends ActiveInteractionPower {
 
     private final Predicate<CachedBlockPosition> blockCondition;
 
-    public PreventBlockUsePower(PowerType<?> type, LivingEntity entity, Predicate<CachedBlockPosition> blockCondition) {
-        super(type, entity);
+    private final Consumer<Entity> entityAction;
+    private final Consumer<Triple<World, BlockPos, Direction>> blockAction;
+
+    private final EnumSet<Direction> directions;
+    private final EnumSet<BlockUsagePhase> usePhases;
+
+    public PreventBlockUsePower(PowerType<?> type, LivingEntity entity, Consumer<Entity> entityAction, Consumer<Triple<World, BlockPos, Direction>> blockAction, Consumer<Pair<World, StackReference>> resultItemAction, Consumer<Pair<World, StackReference>> heldItemAction, Predicate<CachedBlockPosition> blockCondition, Predicate<Pair<World, ItemStack>> itemCondition, ItemStack resultStack, EnumSet<Direction> directions, EnumSet<Hand> hands, EnumSet<BlockUsagePhase> usePhases, int priority) {
+        super(type, entity, hands, ActionResult.FAIL, itemCondition, heldItemAction, resultStack, resultItemAction, priority);
         this.blockCondition = blockCondition;
+        this.entityAction = entityAction;
+        this.blockAction = blockAction;
+        this.directions = directions;
+        this.usePhases = usePhases;
     }
 
-    public boolean doesPrevent(WorldView world, BlockPos pos) {
-        return blockCondition == null || blockCondition.test(new CachedBlockPosition(world, pos, true));
+    public void executeActions(BlockHitResult hitResult, Hand hand) {
+
+        if (blockAction != null) {
+            this.blockAction.accept(Triple.of(entity.getWorld(), hitResult.getBlockPos(), hitResult.getSide()));
+        }
+
+        if (entityAction != null) {
+            this.entityAction.accept(entity);
+        }
+
+        if (entity instanceof PlayerEntity player) {
+            this.performActorItemStuff(this, player, hand);
+        }
+
+    }
+
+    public boolean doesPrevent(BlockUsagePhase usePhase, BlockHitResult hitResult, ItemStack heldStack, Hand hand) {
+        return super.shouldExecute(hand, heldStack)
+            && usePhases.contains(usePhase)
+            && directions.contains(hitResult.getSide())
+            && (blockCondition == null || blockCondition.test(new CachedBlockPosition(entity.getWorld(), hitResult.getBlockPos(), true)));
+    }
+
+    public static boolean doesPrevent(Entity holder, BlockUsagePhase usePhase, BlockHitResult hitResult, ItemStack heldStack, Hand hand) {
+
+        CallInstance<ActiveInteractionPower> aipci = new CallInstance<>();
+        aipci.add(holder, PreventBlockUsePower.class, p -> p.doesPrevent(usePhase, hitResult, heldStack, hand));
+
+        for (int i = aipci.getMaxPriority(); i >= aipci.getMinPriority(); i--) {
+            aipci.forEach(i, p -> ((PreventBlockUsePower) p).executeActions(hitResult, hand));
+        }
+
+        return !aipci.isEmpty();
+
     }
 
     public static PowerFactory createFactory() {
         return new PowerFactory<>(
             Apoli.identifier("prevent_block_use"),
             new SerializableData()
-                .add("block_condition", ApoliDataTypes.BLOCK_CONDITION, null),
+                .add("entity_action", ApoliDataTypes.ENTITY_ACTION, null)
+                .add("block_action", ApoliDataTypes.BLOCK_ACTION, null)
+                .add("result_item_action", ApoliDataTypes.ITEM_ACTION, null)
+                .add("held_item_action", ApoliDataTypes.ITEM_ACTION, null)
+                .add("block_condition", ApoliDataTypes.BLOCK_CONDITION, null)
+                .add("item_condition", ApoliDataTypes.ITEM_CONDITION, null)
+                .add("result_stack", SerializableDataTypes.ITEM_STACK, null)
+                .add("directions", SerializableDataTypes.DIRECTION_SET, EnumSet.allOf(Direction.class))
+                .add("hands", SerializableDataTypes.HAND_SET, EnumSet.allOf(Hand.class))
+                .add("usage_phases", ApoliDataTypes.BLOCK_USAGE_PHASE_SET, EnumSet.allOf(BlockUsagePhase.class))
+                .add("priority", SerializableDataTypes.INT, 0),
             data -> (powerType, livingEntity) -> new PreventBlockUsePower(
                 powerType,
                 livingEntity,
-                data.get("block_condition")
+                data.get("entity_action"),
+                data.get("block_action"),
+                data.get("result_item_action"),
+                data.get("held_item_action"),
+                data.get("block_condition"),
+                data.get("item_condition"),
+                data.get("result_stack"),
+                data.get("directions"),
+                data.get("hands"),
+                data.get("usage_phases"),
+                data.get("priority")
             )
         ).allowCondition();
     }

--- a/src/main/java/io/github/apace100/apoli/power/Prioritized.java
+++ b/src/main/java/io/github/apace100/apoli/power/Prioritized.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 public interface Prioritized<T extends Power & Prioritized<T>> {
 
@@ -69,6 +68,10 @@ public interface Prioritized<T extends Power & Prioritized<T>> {
                 this.maxPriority = priority;
             }
 
+        }
+
+        public boolean isEmpty() {
+            return buckets.isEmpty();
         }
 
     }

--- a/src/main/java/io/github/apace100/apoli/util/ActionResultUtil.java
+++ b/src/main/java/io/github/apace100/apoli/util/ActionResultUtil.java
@@ -1,0 +1,12 @@
+package io.github.apace100.apoli.util;
+
+import net.minecraft.util.ActionResult;
+
+public class ActionResultUtil {
+
+    public static boolean shouldOverride(ActionResult oldResult, ActionResult newResult) {
+        return (newResult.isAccepted() && !oldResult.isAccepted())
+            || (newResult.shouldSwingHand() && !oldResult.shouldSwingHand());
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/util/BlockUsagePhase.java
+++ b/src/main/java/io/github/apace100/apoli/util/BlockUsagePhase.java
@@ -1,0 +1,6 @@
+package io.github.apace100.apoli.util;
+
+public enum BlockUsagePhase {
+    BLOCK,
+    ITEM
+}

--- a/src/main/java/io/github/apace100/apoli/util/PriorityPhase.java
+++ b/src/main/java/io/github/apace100/apoli/util/PriorityPhase.java
@@ -1,0 +1,25 @@
+package io.github.apace100.apoli.util;
+
+import java.util.function.IntPredicate;
+
+public enum PriorityPhase implements IntPredicate {
+
+    BEFORE {
+
+        @Override
+        public boolean test(int value) {
+            return value >= 0;
+        }
+
+    },
+
+    AFTER {
+
+        @Override
+        public boolean test(int value) {
+            return value < 0;
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR changes the implementation of the `*_block_use` power types to be consistent with the behavior of the `*_entity_use` power types. It seems that this was already partially implemented (only on the client-side), so I decided to complete the implementation with this PR.

This also changes the behavior of `edible_item` power type slightly, where the items that can be used on blocks are no longer prevented from being used. To accommodate for such use-cases (and some QoL stuff), this PR adds these new fields to the `*_block_use` power types:

> [!NOTE]
> Powers with a priority value of equal or greater than 1 will be executed and will override the result of the interaction while powers with a priority value of equal or less than -1 will only be executed if the interaction results in a pass.
>
> Powers with a priority value of 0 will be executed alongside the interaction and will **not** override the end result.

Field | Type | Default | Description
------|------|---------|------------
`use_phases` | Array of Block Usage Phases | `["block", "item"]` | Determines at which point the actions should be executed/prevented.

---

A block usage phase is a string that determines the phase when interacting with a block.

> [!NOTE]
> The listed values are ordered by priority, with `"block"` being first and `"item"` being last.

Name | Description
-----|------------
`"block"` | Determines that the player interacts with a block.
`"item"` | Determines that the player used an item to interact with a block.

---
