### PR TITLE
Add `leash` bi-entity action type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/access/LeashableEntity.java
+++ b/src/main/java/io/github/apace100/apoli/access/LeashableEntity.java
@@ -1,0 +1,6 @@
+package io.github.apace100.apoli.access;
+
+public interface LeashableEntity {
+    boolean apoli$isCustomLeashed();
+    void apoli$setCustomLeashed(boolean customLeashed);
+}

--- a/src/main/java/io/github/apace100/apoli/mixin/MobEntityMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/MobEntityMixin.java
@@ -1,6 +1,7 @@
 package io.github.apace100.apoli.mixin;
 
-import com.llamalad7.mixinextras.injector.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import io.github.apace100.apoli.access.LeashableEntity;
 import io.github.apace100.apoli.power.ActionOnItemPickupPower;
 import io.github.apace100.apoli.power.PreventItemPickupPower;
 import net.minecraft.entity.EntityType;
@@ -8,12 +9,16 @@ import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.Targeter;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MobEntity.class)
-public abstract class MobEntityMixin extends LivingEntity implements Targeter {
+public abstract class MobEntityMixin extends LivingEntity implements Targeter, LeashableEntity {
 
     protected MobEntityMixin(EntityType<? extends LivingEntity> entityType, World world) {
         super(entityType, world);
@@ -29,6 +34,29 @@ public abstract class MobEntityMixin extends LivingEntity implements Targeter {
         ActionOnItemPickupPower.executeActions(itemEntity, this);
         return true;
 
+    }
+
+    @Unique
+    private boolean apoli$customLeashed;
+
+    @Override
+    public boolean apoli$isCustomLeashed() {
+        return apoli$customLeashed;
+    }
+
+    @Override
+    public void apoli$setCustomLeashed(boolean customLeashed) {
+        this.apoli$customLeashed = customLeashed;
+    }
+
+    @WrapWithCondition(method = "detachLeash", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/mob/MobEntity;dropItem(Lnet/minecraft/item/ItemConvertible;)Lnet/minecraft/entity/ItemEntity;"))
+    private boolean apoli$preventDroppingLeashOnCustom(MobEntity mob, ItemConvertible item) {
+        return !this.apoli$isCustomLeashed();
+    }
+
+    @Inject(method = "detachLeash", at = @At("TAIL"))
+    private void apoli$resetCustomLeashStatus(boolean sendPacket, boolean dropItem, CallbackInfo ci) {
+        this.apoli$setCustomLeashed(false);
     }
 
 }

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/BiEntityActions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/BiEntityActions.java
@@ -34,6 +34,7 @@ public class BiEntityActions {
         register(DamageAction.getFactory());
         register(AddToSetAction.getFactory());
         register(RemoveFromSetAction.getFactory());
+        register(LeashAction.getFactory());
     }
 
     private static void register(ActionFactory<Pair<Entity, Entity>> actionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/action/bientity/LeashAction.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/action/bientity/LeashAction.java
@@ -1,0 +1,37 @@
+package io.github.apace100.apoli.power.factory.action.bientity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.access.LeashableEntity;
+import io.github.apace100.apoli.power.factory.action.ActionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.util.Pair;
+
+public class LeashAction {
+
+    public static void action(SerializableData.Instance data, Pair<Entity, Entity> actorAndTarget) {
+
+        Entity actor = actorAndTarget.getLeft();
+        Entity target = actorAndTarget.getRight();
+
+        if (actor == null || !(target instanceof MobEntity mobTarget) || !(mobTarget instanceof LeashableEntity leashable)) {
+            return;
+        }
+
+        if (!mobTarget.isLeashed()) {
+            leashable.apoli$setCustomLeashed(true);
+            mobTarget.attachLeash(actor, true);
+        }
+
+    }
+
+    public static ActionFactory<Pair<Entity, Entity>> getFactory() {
+        return new ActionFactory<>(
+            Apoli.identifier("leash"),
+            new SerializableData(),
+            LeashAction::action
+        );
+    }
+
+}


### PR DESCRIPTION
This PR adds the `leash` bi-entity action type from eggolib. This also fixes an issue with the previous implementation, where custom leashes attached via this type drops a leash item