### PR TITLE
Add `prevent_entity_selection` power type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/GameRendererMixin.java
@@ -1,5 +1,6 @@
 package io.github.apace100.apoli.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.*;
 import net.fabricmc.api.EnvType;
@@ -218,4 +219,12 @@ public abstract class GameRendererMixin {
         BlockPos.stream(cameraBox).forEach(p -> set.add(p.toImmutable()));
         return set;
     }
+
+    @ModifyExpressionValue(method = "method_18144", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;canHit()Z"))
+    private static boolean apoli$preventEntitySelection(boolean original, Entity target) {
+        Entity cameraEntity = MinecraftClient.getInstance().getCameraEntity();
+        return original
+            && !PowerHolderComponent.hasPower(cameraEntity, PreventEntitySelectionPower.class, p -> p.doesPrevent(target));
+    }
+
 }

--- a/src/main/java/io/github/apace100/apoli/power/PreventEntitySelectionPower.java
+++ b/src/main/java/io/github/apace100/apoli/power/PreventEntitySelectionPower.java
@@ -1,0 +1,40 @@
+package io.github.apace100.apoli.power;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.PowerFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.Pair;
+
+import java.util.function.Predicate;
+
+public class PreventEntitySelectionPower extends Power {
+
+    private final Predicate<Pair<Entity, Entity>> biEntityCondition;
+
+    public PreventEntitySelectionPower(PowerType<?> type, LivingEntity entity, Predicate<Pair<Entity, Entity>> biEntityCondition) {
+        super(type, entity);
+        this.biEntityCondition = biEntityCondition;
+    }
+
+    public boolean doesPrevent(Entity target) {
+        return biEntityCondition == null
+            || biEntityCondition.test(new Pair<>(entity, target));
+    }
+
+    public static PowerFactory createFactory() {
+        return new PowerFactory<>(
+            Apoli.identifier("prevent_entity_selection"),
+            new SerializableData()
+                .add("bientity_condition", ApoliDataTypes.BIENTITY_CONDITION, null),
+            data -> (powerType, livingEntity) -> new PreventEntitySelectionPower(
+                powerType,
+                livingEntity,
+                data.get("bientity_condition")
+            )
+        ).allowCondition();
+    }
+
+}

--- a/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/PowerFactories.java
@@ -135,6 +135,7 @@ public class PowerFactories {
         register(PreventBlockPlacePower::createFactory);
         register(EntitySetPower::createFactory);
         register(ModifyFovPower::createFactory);
+        register(PreventEntitySelectionPower::createFactory);
     }
 
     private static void register(PowerFactory<?> powerFactory) {

--- a/src/test/resources/data/apoli/powers/hit_through_pets.json
+++ b/src/test/resources/data/apoli/powers/hit_through_pets.json
@@ -1,0 +1,10 @@
+{
+    "type": "apoli:prevent_entity_selection",
+    "bientity_condition": {
+        "type": "apoli:owner"
+    },
+    "condition": {
+        "type": "apoli:sneaking",
+        "inverted": true
+    }
+}


### PR DESCRIPTION
This PR adds a new power type: `prevent_entity_selection`, which prevents the selection of entities for the player that has the power.

> [!NOTE]
> Preventing the "selection" of entities means that the player won't be able to attack or interact with the affected entities by passing it through whatever behind the said entities.
>
> In the context of this power type, the **'actor'** is the player that has the power while the **'target'** is the entity at the crosshair of the player.

> [!WARNING]
> The bi-entity condition specified in the `bientity_condition` field is only evaluated on the <span style="color:goldenrod"><b>client-side</b></span>, therefore, using bi-entity condition types that only work on the server-side will not work.

Field | Type | Default | Description
------|------|---------|------------
`bientity_condition` | Bi-entity Condition Type | *optional* | If specified, the **'target'** will only be prevented from being selected if this bi-entity condition is fulfilled by either or both the **'actor'** and **'target'**.