### PR TITLE
Add "block" item condition type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/ItemConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/ItemConditions.java
@@ -16,6 +16,7 @@ public class ItemConditions {
     public static void register() {
         MetaConditions.register(ApoliDataTypes.ITEM_CONDITION, ItemConditions::register);
         register(FoodCondition.getFactory());
+        register(BlockCondition.getFactory());
         register(SmeltableCondition.getFactory());
         register(IngredientCondition.getFactory());
         register(ArmorValueCondition.getFactory());

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/item/BlockCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/item/BlockCondition.java
@@ -1,0 +1,25 @@
+package io.github.apace100.apoli.power.factory.condition.item;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Pair;
+import net.minecraft.world.World;
+
+public class BlockCondition {
+
+    public static boolean condition(SerializableData.Instance data, Pair<World, ItemStack> worldAndStack) {
+        return worldAndStack.getRight().getItem() instanceof BlockItem;
+    }
+
+    public static ConditionFactory<Pair<World, ItemStack>> getFactory() {
+        return new ConditionFactory<>(
+                Apoli.identifier("block"),
+                new SerializableData(),
+                BlockCondition::condition
+        );
+    }
+
+}


### PR DESCRIPTION
A simple item condition that checks if the item is an instance of BlockItem.

Test power:
```json
{
  "type": "apoli:active_self",
  "key": "key.attack",
  "entity_action": {
    "type": "apoli:if_else",
    "condition": {
      "type": "apoli:inventory",
      "slot": "weapon.mainhand",
      "item_condition": {
        "type": "apoli:block"
      }
    },
    "if_action": {
      "type": "apoli:execute_command",
      "command": "say True"
    },
    "else_action": {
      "type": "apoli:execute_command",
      "command": "say False"
    }
  }
}