### PR TITLE
Add "teammates" bi-entity condition

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/BiEntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/BiEntityConditions.java
@@ -32,6 +32,7 @@ public class BiEntityConditions {
         register(RelativeRotationCondition.getFactory());
         register(EqualCondition.getFactory());
         register(InEntitySetCondition.getFactory());
+        register(TeammatesCondition.getFactory());
     }
 
     private static void register(ConditionFactory<Pair<Entity, Entity>> conditionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/bientity/TeammatesCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/bientity/TeammatesCondition.java
@@ -1,0 +1,42 @@
+package io.github.apace100.apoli.power.factory.condition.bientity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.scoreboard.Team;
+import net.minecraft.util.Pair;
+
+public class TeammatesCondition {
+
+    public static boolean condition(SerializableData.Instance data, Pair<Entity, Entity> actorAndTarget) {
+        Entity actor = actorAndTarget.getLeft();
+        Entity target = actorAndTarget.getRight();
+
+        if (actor == null || target == null) {
+            return false;
+        }
+
+        Team actorTeam = actor.getScoreboardTeam();
+        Team targetTeam = target.getScoreboardTeam();
+
+        boolean allowEmpty = data.getBoolean("allow_empty");
+
+        if (actorTeam == null || targetTeam == null) {
+            return allowEmpty && (actorTeam == null && targetTeam == null);
+        }
+
+        return actorTeam.isEqual(targetTeam);
+    }
+
+    public static ConditionFactory<Pair<Entity, Entity>> getFactory() {
+        return new ConditionFactory<>(
+            Apoli.identifier("teammates"),
+            new SerializableData()
+                .add("allow_empty", SerializableDataTypes.BOOLEAN, false),
+            TeammatesCondition::condition
+        );
+    }
+
+}


### PR DESCRIPTION
This PR adds a condition that checks if two entities are on the same team. The condition has a boolean "allow_empty" field (false by default), allowing flexibility in considering entities without teams as teammates.

Usage example:
```json
{
    "type": "apoli:action_on_hit",
    "bientity_action": {
      "type": "apoli:if_else",
      "condition": {
        "type": "apoli:teammates",
        "allow_empty": true
      },
      "if_action": {
        "type": "apoli:actor_action",
        "action": {
          "type": "apoli:execute_command",
          "command": "say True"
        }
      },
      "else_action": {
        "type": "apoli:actor_action",
        "action": {
          "type": "apoli:execute_command",
          "command": "say False"
        }
      }
    }
  }
```