### PR TITLE
Add modifiers to `apoli:add_velocity` actions

### DIFF
--- a/src/main/java/io/github/apace100/apoli/action/type/bientity/AddVelocityBiEntityActionType.java
+++ b/src/main/java/io/github/apace100/apoli/action/type/bientity/AddVelocityBiEntityActionType.java
@@ -6,7 +6,10 @@ import io.github.apace100.apoli.action.type.BiEntityActionType;
 import io.github.apace100.apoli.action.type.BiEntityActionTypes;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.data.TypedDataObjectFactory;
+import io.github.apace100.apoli.util.MiscUtil;
 import io.github.apace100.apoli.util.Space;
+import io.github.apace100.apoli.util.modifier.Modifier;
+import io.github.apace100.apoli.util.modifier.ModifierUtil;
 import io.github.apace100.apoli.util.requirement.BiEntityRequirement;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataType;
@@ -18,6 +21,7 @@ import org.apache.commons.lang3.function.TriConsumer;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
+import java.util.List;
 import java.util.function.BiFunction;
 
 public class AddVelocityBiEntityActionType extends BiEntityActionType {
@@ -28,17 +32,29 @@ public class AddVelocityBiEntityActionType extends BiEntityActionType {
             .add("y", SerializableDataTypes.FLOAT, 0F)
             .add("z", SerializableDataTypes.FLOAT, 0F)
             .addFunctionedDefault("velocity", ApoliDataTypes.VECTOR_3_FLOAT, data -> new Vector3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z")))
+            .add("x_modifier", Modifier.DATA_TYPE, null)
+            .addFunctionedDefault("x_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("x_modifier")))
+            .add("y_modifier", Modifier.DATA_TYPE, null)
+            .addFunctionedDefault("y_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("y_modifier")))
+            .add("z_modifier", Modifier.DATA_TYPE, null)
+            .addFunctionedDefault("z_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("z_modifier")))
             .add("reference", SerializableDataType.enumValue(Reference.class), Reference.POSITION)
             .add("set", SerializableDataTypes.BOOLEAN, false),
         data -> new AddVelocityBiEntityActionType(
             data.get("velocity"),
             data.get("reference"),
-            data.get("set")
+            data.get("set"),
+            data.get("x_modifiers"),
+            data.get("y_modifiers"),
+            data.get("z_modifiers")
         ),
         (actionType, serializableData) -> serializableData.instance()
             .set("velocity", actionType.velocity)
             .set("reference", actionType.reference)
             .set("set", actionType.set)
+            .set("x_modifiers", actionType.xModifiers)
+            .set("y_modifiers", actionType.yModifiers)
+            .set("z_modifiers", actionType.zModifiers)
     );
 
     private final Vector3f velocity;
@@ -46,10 +62,22 @@ public class AddVelocityBiEntityActionType extends BiEntityActionType {
 
     private final boolean set;
 
+    private final List<Modifier> xModifiers;
+    private final List<Modifier> yModifiers;
+    private final List<Modifier> zModifiers;
+
     public AddVelocityBiEntityActionType(Vector3f velocity, Reference reference, boolean set) {
+        this(velocity, reference, set, List.of(), List.of(), List.of());
+    }
+
+
+    public AddVelocityBiEntityActionType(Vector3f velocity, Reference reference, boolean set, List<Modifier> xModifiers, List<Modifier> yModifiers, List<Modifier> zModifiers) {
         this.velocity = velocity;
         this.reference = reference;
         this.set = set;
+        this.xModifiers = xModifiers;
+        this.yModifiers = yModifiers;
+        this.zModifiers = zModifiers;
     }
 
     @Override
@@ -59,6 +87,11 @@ public class AddVelocityBiEntityActionType extends BiEntityActionType {
         Entity target = context.target();
 
         Vector3f velocityCopy = new Vector3f(velocity);
+        velocityCopy.set(
+            ModifierUtil.applyModifiers(actor, this.xModifiers, velocityCopy.x()),
+            ModifierUtil.applyModifiers(actor, this.yModifiers, velocityCopy.y()),
+            ModifierUtil.applyModifiers(actor, this.zModifiers, velocityCopy.z())
+        );
         TriConsumer<Float, Float, Float> method = set
             ? target::setVelocity
             : target::addVelocity;

--- a/src/main/java/io/github/apace100/apoli/action/type/bientity/AddVelocityBiEntityActionType.java
+++ b/src/main/java/io/github/apace100/apoli/action/type/bientity/AddVelocityBiEntityActionType.java
@@ -33,10 +33,10 @@ public class AddVelocityBiEntityActionType extends BiEntityActionType {
             .add("z", SerializableDataTypes.FLOAT, 0F)
             .addFunctionedDefault("velocity", ApoliDataTypes.VECTOR_3_FLOAT, data -> new Vector3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z")))
             .add("x_modifier", Modifier.DATA_TYPE, null)
-            .addFunctionedDefault("x_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("x_modifier")))
             .add("y_modifier", Modifier.DATA_TYPE, null)
-            .addFunctionedDefault("y_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("y_modifier")))
             .add("z_modifier", Modifier.DATA_TYPE, null)
+            .addFunctionedDefault("x_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("x_modifier")))
+            .addFunctionedDefault("y_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("y_modifier")))
             .addFunctionedDefault("z_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("z_modifier")))
             .add("reference", SerializableDataType.enumValue(Reference.class), Reference.POSITION)
             .add("set", SerializableDataTypes.BOOLEAN, false),

--- a/src/main/java/io/github/apace100/apoli/action/type/entity/AddVelocityEntityActionType.java
+++ b/src/main/java/io/github/apace100/apoli/action/type/entity/AddVelocityEntityActionType.java
@@ -6,13 +6,18 @@ import io.github.apace100.apoli.action.type.EntityActionType;
 import io.github.apace100.apoli.action.type.EntityActionTypes;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.data.TypedDataObjectFactory;
+import io.github.apace100.apoli.util.MiscUtil;
 import io.github.apace100.apoli.util.Space;
+import io.github.apace100.apoli.util.modifier.Modifier;
+import io.github.apace100.apoli.util.modifier.ModifierUtil;
 import io.github.apace100.calio.data.SerializableData;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.entity.Entity;
 import org.apache.commons.lang3.function.TriConsumer;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
+
+import java.util.List;
 
 public class AddVelocityEntityActionType extends EntityActionType {
 
@@ -22,17 +27,29 @@ public class AddVelocityEntityActionType extends EntityActionType {
             .add("y", SerializableDataTypes.FLOAT, 0F)
             .add("z", SerializableDataTypes.FLOAT, 0F)
             .addFunctionedDefault("velocity", ApoliDataTypes.VECTOR_3_FLOAT, data -> new Vector3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z")))
+            .add("x_modifier", Modifier.DATA_TYPE, null)
+            .addFunctionedDefault("x_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("x_modifier")))
+            .add("y_modifier", Modifier.DATA_TYPE, null)
+            .addFunctionedDefault("y_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("y_modifier")))
+            .add("z_modifier", Modifier.DATA_TYPE, null)
+            .addFunctionedDefault("z_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("z_modifier")))
             .add("space", ApoliDataTypes.SPACE, Space.WORLD)
             .add("set", SerializableDataTypes.BOOLEAN, false),
         data -> new AddVelocityEntityActionType(
             data.get("velocity"),
             data.get("space"),
-            data.get("set")
+            data.get("set"),
+            data.get("x_modifiers"),
+            data.get("y_modifiers"),
+            data.get("z_modifiers")
         ),
         (actionType, serializableData) -> serializableData.instance()
             .set("velocity", actionType.velocity)
             .set("space", actionType.space)
             .set("set", actionType.set)
+            .set("x_modifiers", actionType.xModifiers)
+            .set("y_modifiers", actionType.yModifiers)
+            .set("z_modifiers", actionType.zModifiers)
     );
 
     private final Vector3f velocity;
@@ -40,10 +57,21 @@ public class AddVelocityEntityActionType extends EntityActionType {
 
     private final boolean set;
 
+    private final List<Modifier> xModifiers;
+    private final List<Modifier> yModifiers;
+    private final List<Modifier> zModifiers;
+
     public AddVelocityEntityActionType(Vector3f velocity, Space space, boolean set) {
+        this(velocity, space, set, List.of(), List.of(), List.of());
+    }
+
+    public AddVelocityEntityActionType(Vector3f velocity, Space space, boolean set, List<Modifier> xModifiers, List<Modifier> yModifiers, List<Modifier> zModifiers) {
         this.velocity = velocity;
         this.space = space;
         this.set = set;
+        this.xModifiers = xModifiers;
+        this.yModifiers = yModifiers;
+        this.zModifiers = zModifiers;
     }
 
     @Override
@@ -52,6 +80,11 @@ public class AddVelocityEntityActionType extends EntityActionType {
         Entity entity = context.entity();
 
         Vector3f velocityCopy = new Vector3f(velocity);
+        velocityCopy.set(
+            ModifierUtil.applyModifiers(entity, this.xModifiers, velocityCopy.x()),
+            ModifierUtil.applyModifiers(entity, this.yModifiers, velocityCopy.y()),
+            ModifierUtil.applyModifiers(entity, this.zModifiers, velocityCopy.z())
+        );
         TriConsumer<Float, Float, Float> method = set
             ? entity::setVelocity
             : entity::addVelocity;

--- a/src/main/java/io/github/apace100/apoli/action/type/entity/AddVelocityEntityActionType.java
+++ b/src/main/java/io/github/apace100/apoli/action/type/entity/AddVelocityEntityActionType.java
@@ -28,10 +28,10 @@ public class AddVelocityEntityActionType extends EntityActionType {
             .add("z", SerializableDataTypes.FLOAT, 0F)
             .addFunctionedDefault("velocity", ApoliDataTypes.VECTOR_3_FLOAT, data -> new Vector3f(data.getFloat("x"), data.getFloat("y"), data.getFloat("z")))
             .add("x_modifier", Modifier.DATA_TYPE, null)
-            .addFunctionedDefault("x_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("x_modifier")))
             .add("y_modifier", Modifier.DATA_TYPE, null)
-            .addFunctionedDefault("y_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("y_modifier")))
             .add("z_modifier", Modifier.DATA_TYPE, null)
+            .addFunctionedDefault("x_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("x_modifier")))
+            .addFunctionedDefault("y_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("y_modifier")))
             .addFunctionedDefault("z_modifiers", Modifier.LIST_TYPE, data -> MiscUtil.singletonListOrEmpty(data.get("z_modifier")))
             .add("space", ApoliDataTypes.SPACE, Space.WORLD)
             .add("set", SerializableDataTypes.BOOLEAN, false),


### PR DESCRIPTION
This pull request simply adds `x_modifier[s]`, `y_modifier[s]` and `z_modifier[s]` fields to both of the `apoli:add_velocity` actions, massively increasing their flexibility by virtue of modifiers being able to reference resources (and of child modifiers being able to appropriately scale the resource). For the bi-entity version of `apoli:add_velocity`, the modifiers are applied based on the `actor`.

An example of what this pull request makes possible:
```json
{
	"type": "apoli:add_velocity",
	"set": true,
	"x": 0.0,
	"y": 0.0,
	"z": 0.0,
	"x_modifier": {
		"operation": "set_total",
		"amount": 0,
		"resource": "*:speed_x",
		"modifier": {
			"operation": "multiply_total_multiplicative",
			"amount": -0.9999
		}
	},
	"y_modifier": {
		"operation": "set_total",
		"amount": 0,
		"resource": "*:speed_y",
		"modifier": {
			"operation": "multiply_total_multiplicative",
			"amount": -0.9999
		}
	},
	"__comment": "Also supports the list version like similar modifying abilities do",
	"z_modifiers": [
		{
			"operation": "set_total",
			"amount": 0,
			"resource": "*:speed_z",
			"modifier": {
				"operation": "multiply_total_multiplicative",
				"amount": -0.9999
			}
		}
	]
}
```

Resolves #263 (and #264 to a lesser extent).