### PR TITLE
Backports `entity_in_radius` entity condition type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
@@ -512,6 +512,7 @@ public class EntityConditions {
         register(RaycastCondition.getFactory());
         register(ElytraFlightPossibleCondition.getFactory());
         register(InventoryCondition.getFactory());
+        register(EntityInRadiusCondition.getFactory());
     }
 
     private static void register(ConditionFactory<Entity> conditionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/EntityInRadiusCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/EntityInRadiusCondition.java
@@ -1,0 +1,75 @@
+package io.github.apace100.apoli.power.factory.condition.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.apoli.util.Shape;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataType;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Pair;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class EntityInRadiusCondition {
+
+    public static ConditionFactory<Entity> getFactory() {
+        return new ConditionFactory<>(
+                Apoli.identifier("entity_in_radius"),
+                new SerializableData()
+                        .add("bientity_condition", ApoliDataTypes.BIENTITY_CONDITION, null)
+                        .add("shape", SerializableDataType.enumValue(Shape.class), Shape.CUBE)
+                        .add("radius", SerializableDataTypes.FLOAT)
+                        .add("comparison", ApoliDataTypes.COMPARISON, Comparison.GREATER_THAN_OR_EQUAL)
+                        .add("compare_to", SerializableDataTypes.INT, 1),
+                EntityInRadiusCondition::condition
+        );
+    }
+
+    private static boolean condition(SerializableData.Instance data, Entity actor) {
+        // Get parameters from data
+        Predicate<Pair<Entity, Entity>> bientityCondition = data.get("bientity_condition");
+        Shape shape = data.get("shape");
+        float radius = data.getFloat("radius");
+        Comparison comparison = data.get("comparison");
+        int compareTo = data.getInt("compare_to");
+
+        // Calculate center position at actor's feet
+        Vec3d center = new Vec3d(actor.getX(), actor.getBoundingBox().minY, actor.getZ());
+
+        // Create bounding box that covers the entire area
+        double diameter = radius * 2;
+        Box box = Box.of(center, diameter, diameter, diameter);
+
+        // Get entities in the bounding box
+        List<Entity> entities = actor.getWorld().getOtherEntities(actor, box);
+
+        int count = 0;
+        for (Entity target : entities) {
+            // Calculate target's foot position
+            Vec3d targetFeet = new Vec3d(target.getX(), target.getBoundingBox().minY, target.getZ());
+
+            // Calculate differences
+            double dx = Math.abs(center.x - targetFeet.x);
+            double dy = Math.abs(center.y - targetFeet.y);
+            double dz = Math.abs(center.z - targetFeet.z);
+
+            // Calculate distance based on shape
+            double distance = Shape.getDistance(shape, dx, dy, dz);
+
+            // Check if within radius and satisfies bi-entity condition
+            if (distance <= radius &&
+                    (bientityCondition == null || bientityCondition.test(new Pair<>(actor, target)))) {
+                count++;
+            }
+        }
+
+        // Compare count using the specified comparison
+        return comparison.compare(count, compareTo);
+    }
+}

--- a/src/test/resources/data/apoli/powers/entity_in_radius_condition.json
+++ b/src/test/resources/data/apoli/powers/entity_in_radius_condition.json
@@ -1,0 +1,25 @@
+{
+    "type": "apoli:action_over_time",
+    "entity_action": {
+        "type": "apoli:if_else",
+        "condition": {
+            "type": "apoli:entity_in_radius",
+            "bientity_condition": {
+                "type": "apoli:owner"
+            },
+            "shape": "sphere",
+            "radius": 10.0,
+            "comparison": ">=",
+            "compare_to": 3
+        },
+        "if_action": {
+            "type": "apoli:execute_command",
+            "command": "tellraw @s {\"text\":\"Your pets are nearby!\",\"color\":\"green\"}"
+        },
+        "else_action": {
+            "type": "apoli:execute_command",
+            "command": "tellraw @s {\"text\":\"You need more pets nearby!\",\"color\":\"red\"}"
+        }
+    },
+    "interval": 20
+}


### PR DESCRIPTION
This PR backports the `entity_in_radius` entity condition type from 1.21.x version of Apoli, which checks whether there's a specified number of entities that fulfill the specified bi-entity condition within the radius of an area relative to the entity's feet. It accepts these fields:

**NOTE**: In the context of this entity condition type, the 'actor' is the entity while the 'target' are the entities within the radius of the specified area.

It accepts these fields:
Field  | Type | Default | Description
-------|------|---------|-------------
`bientity_condition` | [Bi-entity Condition Type]([../data_types/string.md](https://origins.readthedocs.io/en/1.10.0/types/bientity_condition_types/)) |   | The bi-entity condition to evaluate on either or both the `actor` and `target(s)`.
`shape` | [String](../data_types/string.md) | `"cube"` | Determines the shape of the area used for checking how many entities fulfill the bi-entity condition. Accepts `"cube"`, `"star"`, or `"sphere"`.
`radius` | [Float](https://origins.readthedocs.io/en/1.10.0/types/data_types/float/) | | Determines the radius of the area used for checking how many entities fulfill the bi-entity condition.
`comparison` | [Comparison](https://origins.readthedocs.io/en/1.10.0/types/data_types/comparison/) | `">="` | Determines how the amount of entities that fulfill the bi-entity condition should be compared to a specific value.
`compare_to` | [Integer](https://origins.readthedocs.io/en/1.10.0/types/data_types/integer/) | `1` | The value at which the amount of entities that fulfill the bi-entity condition will be compared to.