### PR TITLE
Backported `has_command_tags` (Entity Condition)

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/EntityConditions.java
@@ -512,6 +512,7 @@ public class EntityConditions {
         register(RaycastCondition.getFactory());
         register(ElytraFlightPossibleCondition.getFactory());
         register(InventoryCondition.getFactory());
+        register(HasCommandTagCondition.getFactory());
     }
 
     private static void register(ConditionFactory<Entity> conditionFactory) {

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/HasCommandTagCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/entity/HasCommandTagCondition.java
@@ -1,0 +1,39 @@
+package io.github.apace100.apoli.power.factory.condition.entity;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.entity.Entity;
+
+import java.util.List;
+import java.util.Set;
+
+public class HasCommandTagCondition {
+
+    public static boolean condition(SerializableData.Instance data, Entity entity) {
+        Set<String> commandTags = entity.getCommandTags();
+
+        if (data.isPresent("command_tag")) {
+            return commandTags.contains(data.getString("command_tag"));
+        }
+
+        if (data.isPresent("command_tags")) {
+            List<String> requiredTags = data.get("command_tags");
+            return commandTags.containsAll(requiredTags);
+        }
+
+        // If neither field is present, check if entity has any command tags
+        return !commandTags.isEmpty();
+    }
+
+    public static ConditionFactory<Entity> getFactory() {
+        return new ConditionFactory<>(
+                Apoli.identifier("has_command_tag"),
+                new SerializableData()
+                        .add("command_tag", SerializableDataTypes.STRING, null)
+                        .add("command_tags", SerializableDataTypes.STRINGS, null),
+                HasCommandTagCondition::condition
+        );
+    }
+}

--- a/src/test/resources/data/apoli/powers/has_command_tag_check_any.json
+++ b/src/test/resources/data/apoli/powers/has_command_tag_check_any.json
@@ -1,0 +1,18 @@
+{
+  "type": "apoli:action_over_time",
+  "entity_action": {
+    "type": "apoli:if_else",
+    "condition": {
+      "type": "apoli:has_command_tag"
+    },
+    "if_action": {
+      "type": "apoli:execute_command",
+      "command": "tellraw @s {\"text\":\"I mean, you have a tag, sure...\",\"color\":\"green\"}"
+    },
+    "else_action": {
+      "type": "apoli:execute_command",
+      "command": "tellraw @s {\"text\":\"Damn, no tag? Nerd!\",\"color\":\"red\"}"
+    }
+  },
+  "interval": 20
+}

--- a/src/test/resources/data/apoli/powers/has_command_tag_check_array.json
+++ b/src/test/resources/data/apoli/powers/has_command_tag_check_array.json
@@ -1,0 +1,22 @@
+{
+  "type": "apoli:action_over_time",
+  "entity_action": {
+    "type": "apoli:if_else",
+    "condition": {
+      "type": "apoli:has_command_tag",
+      "command_tags": [
+        "test_1",
+        "test_2"
+      ]
+    },
+    "if_action": {
+      "type": "apoli:execute_command",
+      "command": "tellraw @s {\"text\":\"You have all the right tags!\",\"color\":\"green\"}"
+    },
+    "else_action": {
+      "type": "apoli:execute_command",
+      "command": "tellraw @s {\"text\":\"You do NOT have all the right tags!\",\"color\":\"red\"}"
+    }
+  },
+  "interval": 20
+}


### PR DESCRIPTION
This PR backports the entity condition type: `has_command_tag`, which checks if an entity has (the specified) command tags.

**NOTE**: If none of the fields are present, this entity condition type will check if the entity has command tags instead.

| Field         | Type             | Default  | Description                                                       |
|---------------|------------------|----------|-------------------------------------------------------------------|
| command_tag   | String           | optional | If specified, checks if the entity has this command tag.          |
| command_tags  | Array of Strings | optional | If specified, checks if the entity has these command tags.        |