### PR TITLE
Fixed empty `hud_render`'s empty resource bars not being 8 pixels like filled resource bars

### DIFF
--- a/src/main/java/io/github/apace100/apoli/screen/PowerHudRenderer.java
+++ b/src/main/java/io/github/apace100/apoli/screen/PowerHudRenderer.java
@@ -1,6 +1,5 @@
 package io.github.apace100.apoli.screen;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import io.github.apace100.apoli.power.HudRendered;
@@ -51,7 +50,7 @@ public class PowerHudRenderer implements GameHudRender {
                     RenderSystem.setShaderTexture(0, currentLocation);
                     lastLocation = currentLocation;
                 }*/
-                context.drawTexture(currentLocation, x, y, 0, 0, barWidth, 5);
+                context.drawTexture(currentLocation, x, y, 0, 0, barWidth, barHeight);
                 int v = 8 + render.getBarIndex() * 10;
                 float fill = hudPower.getFill();
                 if(render.isInverted()) {


### PR DESCRIPTION
Fixed the issue where the empty resource bar isn't 8 pixels like the filled bars.... this change was dumb